### PR TITLE
add a gh action to validate the crd

### DIFF
--- a/.github/workflows/validatecrd.yml
+++ b/.github/workflows/validatecrd.yml
@@ -1,0 +1,19 @@
+name: validate crd
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: nolar/setup-k3d-k3s@v1
+        with:
+          # This is the Kubernetes version used by k3d. See https://kubernetes.io/releases/
+          version: v1.26.5
+      - name: apply crd
+        run: kubectl apply -f config/crd/bases/operator.kyma-project.io_eventings.yaml


### PR DESCRIPTION
this adds a simple gh action that tries to apply the eventing-crd to a k3d cluster to see if it is compliant. this is especially useful if you are working on the CRD.