### PR TITLE
Prevent HPA and Deployment Replica Fight

### DIFF
--- a/pkg/eventing/deployment.go
+++ b/pkg/eventing/deployment.go
@@ -86,7 +86,6 @@ func newDeployment(name, namespace string, publisherConfig env.PublisherConfig, 
 			Namespace: namespace,
 		},
 		Spec: appsv1.DeploymentSpec{
-			Replicas: utils.Int32Ptr(publisherConfig.Replicas),
 			Template: v1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: name,


### PR DESCRIPTION
Set deployment replica to nil so that HPA controls the deployment. Otherwise whenever a deployment is applied it sets the replicate to different than HPA wants.