### PR TITLE
Add missing build tags to e2e tests

### DIFF
--- a/hack/e2e/eventing/delivery/delivery_test.go
+++ b/hack/e2e/eventing/delivery/delivery_test.go
@@ -1,3 +1,6 @@
+//go:build e2e
+// +build e2e
+
 package delivery
 
 import (
@@ -8,9 +11,10 @@ import (
 	"github.com/kyma-project/eventing-manager/hack/e2e/common/eventing"
 
 	"github.com/cloudevents/sdk-go/v2/binding"
+	"github.com/stretchr/testify/require"
+
 	"github.com/kyma-project/eventing-manager/hack/e2e/common"
 	"github.com/kyma-project/eventing-manager/hack/e2e/common/fixtures"
-	"github.com/stretchr/testify/require"
 
 	"github.com/kyma-project/eventing-manager/hack/e2e/common/testenvironment"
 )

--- a/hack/e2e/eventing/setup/setup_test.go
+++ b/hack/e2e/eventing/setup/setup_test.go
@@ -1,3 +1,6 @@
+//go:build e2e
+// +build e2e
+
 package setup
 
 import (


### PR DESCRIPTION
the unit tests are failing because the e2e-test unintentionally get triggered due to the missing build tags. this pr adds them.