### PR TITLE
create ghithub action to run the end-to-end tests without lifecycle manager with nats as a backend

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -6,8 +6,6 @@ env:
   DOCKER_IMAGE: europe-docker.pkg.dev/kyma-project/dev/eventing-manager:PR-${{ github.event.number }}
 
 on:
-  push:
-    branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -3,7 +3,7 @@ name: e2e-without-lifecycle-manager
 env:
   KYMA_STABILITY: "unstable"
   KYMA: "./hack/kyma"
-  DOCKER_IMAGE: europe-docker.pkg.dev/kyma-project/dev/eventing-manager:PR-${{ github.event.number }}
+  MANAGER_IMAGE: europe-docker.pkg.dev/kyma-project/dev/eventing-manager:PR-${{ github.event.number }}
 
 on:
   pull_request:
@@ -29,7 +29,7 @@ jobs:
 
       - name: Install eventing-manager
         run: |
-          make install IMG=$DOCKER_IMAGE
+          make install IMG=$MANAGER_IMAGE
 
       - name: Wait for the 'pull-eventing-manager-build' job to succeed
         uses: kyma-project/wait-for-commit-status-action@2b3ffe09af8b6f40e1213d5fb7f91a7bd41ffb20
@@ -47,7 +47,7 @@ jobs:
       - name: Deploy the controller to the cluster
         run: |
           kubectl create ns kyma-system || true
-          make deploy IMG=$DOCKER_IMAGE
+          make deploy IMG=$MANAGER_IMAGE
 
       - name: Setup NATS
         run: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -12,7 +12,7 @@ on:
     branches: [ "main" ]
 
 jobs:
-  nats:
+  test:
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -78,6 +78,13 @@ jobs:
         run: |
           make e2e-eventing
 
+      - name: On error get eventing
+        if: failure()
+        run: |
+          kubectl get eventing -n kyma-system -oyaml
+
       - name: On error get subscriptions
+        if: failure()
         run: |
           kubectl get subscription test-sub-1-v1alpha1 -n eventing-tests -oyaml
+

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -31,6 +31,14 @@ jobs:
         run: |
           make -C hack/ci/ install-lifecycle-manager
 
+      - name: Install the latest NATS-manager module template
+        run: |
+          make -C hack/ci/ install-latest-nats-module-template-fast
+
+      - name: Enable NATS-manager module
+        run: |
+          make -C hack/ci/ enable-nats-module
+
       - name: Wait for NATS to become Ready
         run: |
           ./hack/ci/check-nats-ready.sh

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,4 +1,4 @@
-name: e2e-w/o-lifecycle-manager
+name: e2e-without-lifecycle-manager
 
 env:
   KYMA_STABILITY: "unstable"
@@ -12,7 +12,7 @@ on:
     branches: [ "main" ]
 
 jobs:
-  e2e-test:
+  nats:
     runs-on: ubuntu-latest
 
     steps:
@@ -55,7 +55,6 @@ jobs:
         run: |
           make -C hack/ci/ get-nats-via-lifecycle-manager
 
-
       - name: Setup and test the eventing-manager
         run: |
           make e2e-setup 
@@ -77,4 +76,3 @@ jobs:
         if: failure()
         run: |
           kubectl get eventing -n kyma-system -o yaml
-

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -32,7 +32,7 @@ jobs:
           kubectl version
           kubectl cluster-info
 
-      - name: Install eventing-manager 
+      - name: Install eventing-manager
         run: |
           make install IMG=$DOCKER_IMAGE
 
@@ -48,19 +48,21 @@ jobs:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           GITHUB_OWNER: "${{ github.repository_owner }}"
           GITHUB_REPO: "eventing-manager"
-      
+
       - name: Deploy the controller to the cluster
         run: |
           kubectl create ns kyma-system || true
           make deploy IMG=$DOCKER_IMAGE
 
-      - name: Get backend {{ matrix.backend }}
+      - name: Setup NATS
         if: {{ matrix.backend }} == 'nats'
         run: |
           make -C hack/ci/ get-nats-via-lifecycle-manager
-        else
+
+      - name: Setup EventMesh
+        if: {{ matrix.backend }} == 'eventmesh'
         run: |
-          echo "implement me!"
+          echo 'implement me'
           exit 1
 
       - name: Setup and test the eventing-manager
@@ -79,7 +81,7 @@ jobs:
         if: failure()
         run: |
           kubectl get nats -n kyma-system -o yaml
-      
+
       - name: On error get eventing CR
         if: failure()
         run: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -14,9 +14,6 @@ on:
 jobs:
   e2e-test:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        backend: [nats, eventmesh]
 
     steps:
       - uses: actions/checkout@v4
@@ -55,15 +52,9 @@ jobs:
           make deploy IMG=$DOCKER_IMAGE
 
       - name: Setup NATS
-        if: {{ matrix.backend }} == 'nats'
         run: |
           make -C hack/ci/ get-nats-via-lifecycle-manager
 
-      - name: Setup EventMesh
-        if: {{ matrix.backend }} == 'eventmesh'
-        run: |
-          echo 'implement me'
-          exit 1
 
       - name: Setup and test the eventing-manager
         run: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -33,6 +33,6 @@ jobs:
 
       - name: Wait for NATS to become Ready
         run: |
-          ./hack/ci/e2e.yml
+          ./hack/ci/check-nats-ready.sh
 
       

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -44,7 +44,7 @@ jobs:
         run: |
           ./hack/ci/check-k8s-resource-is-ready.sh
 
-      - name: Get NATS on error
+      - name: On error get NATS
         if: failure()
         run: |
           kubectl get nats -n kyma-system -o yaml
@@ -77,3 +77,7 @@ jobs:
       - name: Setup and test eventing
         run: |
           make e2e-eventing
+
+      - name: On error get subscriptions
+        run: |
+          kubectl get subscription test-sub-1-v1alpha1 -n eventing-tests -oyaml

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -65,6 +65,10 @@ jobs:
         run: |
           make e2e-eventing
 
+      - name: Test eventing cleanup
+        run: |
+          make e2e-eventing-cleanup
+
       - name: On error get NATS CR
         if: failure()
         run: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -14,6 +14,10 @@ on:
 jobs:
   nats:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        backend: [nats, eventmesh]
+
     steps:
       - uses: actions/checkout@v4
 
@@ -50,9 +54,14 @@ jobs:
           kubectl create ns kyma-system || true
           make deploy IMG=$DOCKER_IMAGE
 
-      - name: Get NATS
+      - name: Get backend {{ matrix.backend }}
+        if: {{ matrix.backend }} == 'nats'
         run: |
           make -C hack/ci/ get-nats-via-lifecycle-manager
+        else
+        run: |
+          echo "implement me!"
+          exit 1
 
       - name: Setup and test the eventing-manager
         run: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -77,13 +77,13 @@ jobs:
         run: |
           make e2e-eventing
 
-      - name: On error get NATS
+      - name: On error get NATS CR
         if: failure()
         run: |
           kubectl get nats -n kyma-system -o yaml
       
-      - name: On error get eventing
+      - name: On error get eventing CR
         if: failure()
         run: |
-          kubectl get eventing -n kyma-system -oyaml
+          kubectl get eventing -n kyma-system -o yaml
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -65,3 +65,15 @@ jobs:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           GITHUB_OWNER: "${{ github.repository_owner }}"
           GITHUB_REPO: "eventing-manager"
+      
+      - name: Deploy the controller to the cluster
+        run: |
+          make deploy IMG=$DOCKER_IMAGE
+
+      - name: Setup and test the eventing-manager
+        run: |
+          make e2e-setup 
+
+      - name: Setup and test eventing
+        run: |
+          make e2e-eventing

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,4 +1,4 @@
-name: e2e
+name: e2e-w/o-lifecycle-manager
 
 env:
   KYMA_STABILITY: "unstable"
@@ -12,7 +12,7 @@ on:
     branches: [ "main" ]
 
 jobs:
-  validate-crd:
+  nats:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -44,7 +44,7 @@ jobs:
         run: |
           ./hack/ci/check-k8s-resource-is-ready.sh
 
-      - name: Get NATS
+      - name: Get NATS on error
         if: failure()
         run: |
           kubectl get nats -n kyma-system -o yaml

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -14,6 +14,8 @@ on:
 jobs:
   nats:
     runs-on: ubuntu-latest
+    matrix:
+        backend: [nats, eventmesh]
     steps:
       - uses: actions/checkout@v4
 
@@ -28,21 +30,9 @@ jobs:
           kubectl version
           kubectl cluster-info
 
-      - name: Deploy lifecycle-manager
+      - name: Get NATS
         run: |
-          make -C hack/ci/ install-lifecycle-manager
-
-      - name: Install the latest NATS-manager module template
-        run: |
-          make -C hack/ci/ install-latest-nats-module-template-fast
-
-      - name: Enable NATS-manager module
-        run: |
-          make -C hack/ci/ enable-nats-module
-
-      - name: Wait for NATS to become Ready
-        run: |
-          ./hack/ci/check-k8s-resource-is-ready.sh
+          make -C hack/ci/ get-nats-via-lifecycle-manager
 
       - name: Install eventing-manager 
         run: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -28,10 +28,6 @@ jobs:
           kubectl version
           kubectl cluster-info
 
-      - name: Get NATS
-        run: |
-          make -C hack/ci/ get-nats-via-lifecycle-manager
-
       - name: Install eventing-manager 
         run: |
           make install IMG=$DOCKER_IMAGE
@@ -52,6 +48,10 @@ jobs:
       - name: Deploy the controller to the cluster
         run: |
           make deploy IMG=$DOCKER_IMAGE
+
+      - name: Get NATS
+        run: |
+          make -C hack/ci/ get-nats-via-lifecycle-manager
 
       - name: Setup and test the eventing-manager
         run: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -47,6 +47,7 @@ jobs:
       
       - name: Deploy the controller to the cluster
         run: |
+          kubectl create ns kyma-system || true
           make deploy IMG=$DOCKER_IMAGE
 
       - name: Get NATS

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -67,7 +67,7 @@ jobs:
 
       - name: Test eventing cleanup
         run: |
-          make e2e-eventing-cleanup
+          make e2e-cleanup
 
       - name: On error get NATS CR
         if: failure()

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -3,6 +3,7 @@ name: e2e
 env:
   KYMA_STABILITY: "unstable"
   KYMA: "./hack/kyma"
+  DOCKER_IMAGE: europe-docker.pkg.dev/kyma-project/dev/eventing-manager:PR-${{ github.event.number }}
 
 on:
   push:
@@ -43,4 +44,24 @@ jobs:
         run: |
           ./hack/ci/check-k8s-resource-is-ready.sh
 
+      - name: Get NATS
+        if: failure()
+        run: |
+          kubectl get nats -n kyma-system -o yaml
       
+      - name: Install eventing-manager 
+        run: |
+          make install IMG=$DOCKER_IMAGE
+
+      - name: Wait for the 'pull-eventing-manager-build' job to succeed
+        uses: kyma-project/wait-for-commit-status-action@2b3ffe09af8b6f40e1213d5fb7f91a7bd41ffb20
+        with:
+          context: "pull-eventing-manager-build"
+          commit_ref: "${{ github.event.pull_request.head.sha }}" # Note: 'github.event.pull_request.head.sha' is not same as 'github.sha' on pull requests.
+          timeout: 600000 # 10 minutes in milliseconds
+          # The check interval is kept long otherwise it will exhaust the GitHub rate limit (More info: https://docs.github.com/en/rest/overview/resources-in-the-rest-api?apiVersion=2022-11-28#rate-limiting)
+          check_interval: 60000 # 1 minute in milliseconds
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          GITHUB_OWNER: "${{ github.repository_owner }}"
+          GITHUB_REPO: "eventing-manager"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -14,8 +14,6 @@ on:
 jobs:
   nats:
     runs-on: ubuntu-latest
-    matrix:
-        backend: [nats, eventmesh]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -12,7 +12,7 @@ on:
     branches: [ "main" ]
 
 jobs:
-  test:
+  e2e-test:
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,38 @@
+name: e2e
+
+env:
+  KYMA_STABILITY: "unstable"
+  KYMA: "./hack/kyma"
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  validate-crd:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install k3d tools
+        run: |
+          make -C hack/ci/ install-k3d-tools
+
+      - name: Install Kyma CLI & setup k3d cluster using kyma CLI
+        run: |
+          make kyma
+          make -C hack/ci/ create-k3d
+          kubectl version
+          kubectl cluster-info
+
+      - name: Deploy lifecycle-manager
+        run: |
+          make -C hack/ci/ install-lifecycle-manager
+
+      - name: Wait for NATS to become Ready
+        run: |
+          ./hack/ci/e2e.yml
+
+      

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -41,6 +41,6 @@ jobs:
 
       - name: Wait for NATS to become Ready
         run: |
-          ./hack/ci/check-nats-ready.sh
+          ./hack/ci/check-k8s-resource-is-ready.sh
 
       

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -44,11 +44,6 @@ jobs:
         run: |
           ./hack/ci/check-k8s-resource-is-ready.sh
 
-      - name: On error get NATS
-        if: failure()
-        run: |
-          kubectl get nats -n kyma-system -o yaml
-      
       - name: Install eventing-manager 
         run: |
           make install IMG=$DOCKER_IMAGE
@@ -74,17 +69,21 @@ jobs:
         run: |
           make e2e-setup 
 
-      - name: Setup and test eventing
+      - name: Setup eventing
+        run: |
+          make e2e-eventing-setup
+
+      - name: Test eventing
         run: |
           make e2e-eventing
 
+      - name: On error get NATS
+        if: failure()
+        run: |
+          kubectl get nats -n kyma-system -o yaml
+      
       - name: On error get eventing
         if: failure()
         run: |
           kubectl get eventing -n kyma-system -oyaml
-
-      - name: On error get subscriptions
-        if: failure()
-        run: |
-          kubectl get subscription test-sub-1-v1alpha1 -n eventing-tests -oyaml
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -24,6 +24,8 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/go-logr/zapr"
+
 	"github.com/kyma-project/eventing-manager/pkg/env"
 	"github.com/kyma-project/eventing-manager/pkg/subscriptionmanager"
 	subscriptionv1alpha1 "github.com/kyma-project/kyma/components/eventing-controller/api/v1alpha1"
@@ -34,7 +36,6 @@ import (
 	"github.com/kyma-project/eventing-manager/pkg/eventing"
 	"github.com/kyma-project/eventing-manager/pkg/k8s"
 
-	"github.com/go-logr/zapr"
 	eventingcontroller "github.com/kyma-project/eventing-manager/internal/controller/eventing"
 	"github.com/kyma-project/kyma/components/eventing-controller/logger"
 	"github.com/kyma-project/kyma/components/eventing-controller/options"

--- a/hack/ci/Makefile
+++ b/hack/ci/Makefile
@@ -27,4 +27,4 @@ enable-nats-module:
 
 .PHONY: get-nats-via-lifecycle-manager
 get-nats-via-lifecycle-manager: install-lifecycle-manager install-latest-nats-module-template-fast enable-nats-module
-	./check-k8s-resource-is-ready.sh 
+	./check-k8s-resource-is-ready.sh 180 nats kyma-system

--- a/hack/ci/Makefile
+++ b/hack/ci/Makefile
@@ -23,7 +23,7 @@ install-latest-nats-module-template-fast: ## Downloads and applies the latest na
 
 .PHONY: enable-nats-module
 enable-nats-module:
-	kyma alpha enable module nats -c fast -f --ci -n kyma-system
+	"${KYMA_CLI}" alpha enable module nats -c fast -f --ci -n kyma-system
 
 .PHONY: wait-until-nats-is-ready
 wait-until-nats-is-ready:

--- a/hack/ci/Makefile
+++ b/hack/ci/Makefile
@@ -24,6 +24,3 @@ install-latest-nats-module-template-fast: ## Downloads and applies the latest na
 .PHONY: enable-nats-module
 enable-nats-module:
 	"${KYMA_CLI}" alpha enable module nats -c fast -f --ci -n kyma-system
-
-.PHONY: wait-until-nats-is-ready
-wait-until-nats-is-ready:

--- a/hack/ci/Makefile
+++ b/hack/ci/Makefile
@@ -24,3 +24,7 @@ install-latest-nats-module-template-fast: ## Downloads and applies the latest na
 .PHONY: enable-nats-module
 enable-nats-module:
 	"${KYMA_CLI}" alpha enable module nats -c fast -f --ci -n kyma-system
+
+.PHONY: get-nats-via-lifecycle-manager
+get-nats-via-lifecycle-manager: install-lifecycle-manager install-latest-nats-module-template-fast enable-nats-module
+	./check-k8s-resource-is-ready.sh 

--- a/hack/ci/Makefile
+++ b/hack/ci/Makefile
@@ -10,3 +10,20 @@ install-k3d-tools: ## Create k3d with kyma CRDs.
 .PHONY: create-k3d
 create-k3d: ## Create k3d with kyma CRDs.
 	"${KYMA_CLI}" provision k3d -p 8081:80@loadbalancer -p 8443:443@loadbalancer --registry-port ${REGISTRY_PORT} --name ${CLUSTER_NAME} --ci
+
+.PHONY: install-lifecycle-manager
+install-lifecycle-manager: ## Deploys lifecycle-manager.
+	"${KYMA_CLI}" alpha deploy \
+		--ci \
+		--force-conflicts
+
+.PHONY: install-latest-nats-module-template-fast
+install-latest-nats-module-template-fast: ## Downloads and applies the latest nats-manager released module-template from fast channel.
+	kubectl apply -f https://github.com/kyma-project/nats-manager/releases/latest/download/module-template.yaml
+
+.PHONY: enable-nats-module
+enable-nats-module:
+	kyma alpha enable module nats -c fast -f --ci -n kyma-system
+
+.PHONY: wait-until-nats-is-ready
+wait-until-nats-is-ready:

--- a/hack/ci/check-k8s-resource-is-ready.sh
+++ b/hack/ci/check-k8s-resource-is-ready.sh
@@ -5,7 +5,7 @@ resource=${2:-nats}
 namespace=${3:-kyma-system}
 
 check-nats-ready() {
-  echo "checking ${resource} in the namespace ${namespace} to become 'Ready' for ${timeouttime} seconds"
+  echo -e "\n checking ${resource} in the namespace ${namespace} to become 'Ready' for ${timeouttime} seconds"
 
   export resource
   export namespace

--- a/hack/ci/check-k8s-resource-is-ready.sh
+++ b/hack/ci/check-k8s-resource-is-ready.sh
@@ -1,9 +1,13 @@
 #!/bin/bash
 
 timeouttime=${1:-180}
+resource=${2:-nats}
+namespace=${3:-kyma-system}
 
 check-nats-ready() {
-  timeout ${timeouttime}  bash -c 'while [[ "$(kubectl get -n kyma-system nats -ojsonpath='{.items[0].status.state}')" != "Ready" ]]; do sleep 1; done'
+  echo "checking ${resource} in the namespace ${namespace} to become 'Ready' for ${timeouttime} seconds"
+
+  timeout ${timeouttime}  bash -c 'while [[ "$(kubectl get -n ${namespace} ${resource} -ojsonpath='{.items[0].status.state}')" != "Ready" ]]; do sleep 1; done'
 
   if [[ $? -ne 0 ]]; then
     echo "NATS was not 'Ready' after ${timeouttime} seconds"

--- a/hack/ci/check-k8s-resource-is-ready.sh
+++ b/hack/ci/check-k8s-resource-is-ready.sh
@@ -14,9 +14,9 @@ check-nats-ready() {
   if [[ $? -ne 0 ]]; then
     echo "NATS was not 'Ready' after ${timeouttime} seconds"
     exit 1
+  else
+    echo "NATS is 'Ready'"
   fi
-
-  echo "NATS is 'Ready'"
 }
 
 check-nats-ready

--- a/hack/ci/check-k8s-resource-is-ready.sh
+++ b/hack/ci/check-k8s-resource-is-ready.sh
@@ -9,6 +9,8 @@ check-nats-ready() {
     echo "NATS was not 'Ready' after ${timeouttime} seconds"
     exit 1
   fi
+
+  echo "NATS is 'Ready'"
 }
 
 check-nats-ready

--- a/hack/ci/check-k8s-resource-is-ready.sh
+++ b/hack/ci/check-k8s-resource-is-ready.sh
@@ -5,7 +5,7 @@ resource=${2:-nats}
 namespace=${3:-kyma-system}
 
 check-nats-ready() {
-  echo -e "\n checking ${resource} in the namespace ${namespace} to become 'Ready' for ${timeouttime} seconds"
+  echo "checking ${resource} in the namespace ${namespace} to become 'Ready' for ${timeouttime} seconds"
 
   export resource
   export namespace

--- a/hack/ci/check-k8s-resource-is-ready.sh
+++ b/hack/ci/check-k8s-resource-is-ready.sh
@@ -7,7 +7,9 @@ namespace=${3:-kyma-system}
 check-nats-ready() {
   echo "checking ${resource} in the namespace ${namespace} to become 'Ready' for ${timeouttime} seconds"
 
-  timeout ${timeouttime}  bash -c 'while [[ "$(kubectl get -n ${namespace} ${resource} -ojsonpath='{.items[0].status.state}')" != "Ready" ]]; do sleep 1; done'
+  export resource
+  export namespace
+  timeout ${timeouttime}  bash -c 'while [[ "$(kubectl get -n $namespace $resource -ojsonpath='{.items[0].status.state}')" != "Ready" ]]; do sleep 1; done'
 
   if [[ $? -ne 0 ]]; then
     echo "NATS was not 'Ready' after ${timeouttime} seconds"

--- a/hack/ci/check-nats-ready.sh
+++ b/hack/ci/check-nats-ready.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+timeouttime=${1:-180}
+
+check-nats-ready() {
+  timeout ${timeouttime}  bash -c 'while [[ "$(kubectl get -n kyma-system nats -ojsonpath='{.items[0].status.state}')" != "Processing" ]]; do sleep 1; done'
+
+  if [[ $? -ne 0 ]]; then
+    echo "NATS was not 'Ready' after ${timeouttime} seconds"
+    exit 1
+  fi
+}
+
+check-nats-ready

--- a/hack/ci/check-nats-ready.sh
+++ b/hack/ci/check-nats-ready.sh
@@ -3,7 +3,7 @@
 timeouttime=${1:-180}
 
 check-nats-ready() {
-  timeout ${timeouttime}  bash -c 'while [[ "$(kubectl get -n kyma-system nats -ojsonpath='{.items[0].status.state}')" != "Processing" ]]; do sleep 1; done'
+  timeout ${timeouttime}  bash -c 'while [[ "$(kubectl get -n kyma-system nats -ojsonpath='{.items[0].status.state}')" != "Ready" ]]; do sleep 1; done'
 
   if [[ $? -ne 0 ]]; then
     echo "NATS was not 'Ready' after ${timeouttime} seconds"

--- a/hack/e2e/common/testenvironment/test_environment.go
+++ b/hack/e2e/common/testenvironment/test_environment.go
@@ -13,11 +13,6 @@ import (
 
 	eventingv1alpha1 "github.com/kyma-project/eventing-manager/api/v1alpha1"
 
-	"github.com/kyma-project/eventing-manager/hack/e2e/common"
-	"github.com/kyma-project/eventing-manager/hack/e2e/common/eventing"
-	"github.com/kyma-project/eventing-manager/hack/e2e/common/fixtures"
-	pkghttp "github.com/kyma-project/eventing-manager/hack/e2e/common/http"
-	"github.com/kyma-project/eventing-manager/hack/e2e/env"
 	ecv1alpha2 "github.com/kyma-project/kyma/components/eventing-controller/api/v1alpha2"
 	"go.uber.org/zap"
 	appsv1 "k8s.io/api/apps/v1"
@@ -28,6 +23,12 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/kyma-project/eventing-manager/hack/e2e/common"
+	"github.com/kyma-project/eventing-manager/hack/e2e/common/eventing"
+	"github.com/kyma-project/eventing-manager/hack/e2e/common/fixtures"
+	pkghttp "github.com/kyma-project/eventing-manager/hack/e2e/common/http"
+	"github.com/kyma-project/eventing-manager/hack/e2e/env"
 )
 
 const (
@@ -89,7 +90,7 @@ func (te *TestEnvironment) CreateTestNamespace() error {
 
 func (te *TestEnvironment) DeleteTestNamespace() error {
 	return common.Retry(FewAttempts, Interval, func() error {
-		// It's fine if the Namespace already exists.
+		// It's fine if the Namespace not exists.
 		return client.IgnoreNotFound(te.K8sClient.Delete(te.Context, fixtures.Namespace(te.TestConfigs.TestNamespace)))
 	})
 }

--- a/hack/e2e/setup/setup_test.go
+++ b/hack/e2e/setup/setup_test.go
@@ -17,14 +17,16 @@ import (
 
 	"github.com/kyma-project/eventing-manager/hack/e2e/common/testenvironment"
 
+	"github.com/pkg/errors"
+
 	eventingv1alpha1 "github.com/kyma-project/eventing-manager/api/v1alpha1"
 	"github.com/kyma-project/eventing-manager/pkg/eventing"
-	"github.com/pkg/errors"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	. "github.com/kyma-project/eventing-manager/hack/e2e/common"
 	. "github.com/kyma-project/eventing-manager/hack/e2e/common/fixtures"
-	"github.com/stretchr/testify/require"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var testEnvironment *testenvironment.TestEnvironment
@@ -56,7 +58,7 @@ func TestMain(m *testing.M) {
 		testEnvironment.Logger.Fatal(err.Error())
 	}
 
-	// wait for an testenvironment.Interval for reconciliation to update status.
+	// wait for a testenvironment.Interval for reconciliation to update status.
 	time.Sleep(testenvironment.Interval)
 
 	// Wait for Eventing CR to get ready.


### PR DESCRIPTION
this PR adds a github action to execute the e2e test with nats as a backend. the eventing manager will be deployed without the lifecycle manager.