### PR TITLE
streamline how github action workflows get triggered

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -8,6 +8,9 @@ env:
 on:
   pull_request:
     branches: [ "main" ]
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
 
 jobs:
   nats:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,5 +1,12 @@
 name: golangci-lint
-on: [pull_request]
+
+on:
+  pull_request:
+    branches: [ "main" ]
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
+
 permissions:
   contents: read
   # Optional: allow read access to pull request. Use with `only-new-issues` option.

--- a/.github/workflows/sink.yml
+++ b/.github/workflows/sink.yml
@@ -15,12 +15,18 @@ on:
     paths:
     - 'hack/e2e/sink/**'
     - '.github/workflows/sink.yml'
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
   pull_request:
     branches:
     - main
     paths:
     - 'hack/e2e/sink/**'
     - '.github/workflows/sink.yml'
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
 
 jobs:
   build:
@@ -68,7 +74,7 @@ jobs:
           org.opencontainers.image.title=E2E Tests Sink
           org.opencontainers.image.description=A webserver imitating an eventing sink that receives events and stores in memory
           org.opencontainers.image.url=https://github.com/kyma-project/eventing-manager/${{ env.E2E_SINK_DIR }}
-    
+
     - name: Build Docker image
       id: build-and-push
       uses: docker/build-push-action@v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,6 @@ on:
       - 'docs/**'
       - '**.md'
 
-
 jobs:
   unit:
     runs-on: ubuntu-latest
@@ -30,22 +29,3 @@ jobs:
       - name: Run tests
         run: |
           make test-only
-
-  validate-crd:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install k3d tools
-        run: |
-          make -C hack/ci/ install-k3d-tools
-
-      - name: Install Kyma CLI & setup k3d cluster using kyma CLI
-        run: |
-          make kyma
-          make -C hack/ci/ create-k3d
-          kubectl version
-          kubectl cluster-info
-
-      - name: apply crd
-        run: kubectl apply -f config/crd/bases/operator.kyma-project.io_eventings.yaml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: validate
+name: test
 
 env:
   KYMA_STABILITY: "unstable"
@@ -7,23 +7,18 @@ env:
 on:
   push:
     branches: [ "main" ]
-    paths:
-      - 'api/**'
-      - 'config/crd/**'
     paths-ignore:
       - 'docs/**'
       - '**.md'
   pull_request:
     branches: [ "main" ]
-    paths:
-      - 'api/**'
-      - 'config/crd/**'
     paths-ignore:
       - 'docs/**'
       - '**.md'
 
+
 jobs:
-  crd:
+  unit:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -26,19 +26,6 @@ jobs:
   crd:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Sync GO dependencies
-        run: |
-          go mod tidy
-          go mod vendor
-      - name: Run tests
-        run: |
-          make test-only
-
-  validate-crd:
-    runs-on: ubuntu-latest
-    steps:
       - uses: actions/checkout@v4
 
       - name: Install k3d tools


### PR DESCRIPTION
This PR tweaks the way github action workflows get triggered:
- changes to `docs/` and to `.md` files will not trigger any workflow
- only changes to `api/` and `config/crd` will trigger the CRD validation