### PR TITLE
remove double import

### DIFF
--- a/test/utils/integration/integration.go
+++ b/test/utils/integration/integration.go
@@ -40,7 +40,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 
 	"github.com/kyma-project/eventing-manager/api/v1alpha1"
-	eventingv1alpha1 "github.com/kyma-project/eventing-manager/api/v1alpha1"
 	eventingctrl "github.com/kyma-project/eventing-manager/internal/controller/eventing"
 	"github.com/kyma-project/eventing-manager/options"
 	"github.com/kyma-project/eventing-manager/pkg/env"
@@ -90,7 +89,7 @@ type TestEnvironment struct {
 
 //nolint:funlen // Used in testing
 func NewTestEnvironment(projectRootDir string, celValidationEnabled bool,
-	allowedEventingCR *eventingv1alpha1.Eventing) (*TestEnvironment, error) {
+	allowedEventingCR *v1alpha1.Eventing) (*TestEnvironment, error) {
 	var err error
 	// setup context
 	ctx := context.Background()
@@ -114,7 +113,7 @@ func NewTestEnvironment(projectRootDir string, celValidationEnabled bool,
 	}
 
 	// add Eventing CRD scheme
-	err = eventingv1alpha1.AddToScheme(scheme.Scheme)
+	err = v1alpha1.AddToScheme(scheme.Scheme)
 	if err != nil {
 		return nil, err
 	}
@@ -354,8 +353,8 @@ func (env TestEnvironment) TearDown() error {
 
 // GetEventingAssert fetches Eventing from k8s and allows making assertions on it.
 func (env TestEnvironment) GetEventingAssert(g *gomega.GomegaWithT,
-	eventing *eventingv1alpha1.Eventing) gomega.AsyncAssertion {
-	return g.Eventually(func() *eventingv1alpha1.Eventing {
+	eventing *v1alpha1.Eventing) gomega.AsyncAssertion {
+	return g.Eventually(func() *v1alpha1.Eventing {
 		gotEventing, err := env.GetEventingFromK8s(eventing.Name, eventing.Namespace)
 		if err != nil {
 			log.Printf("fetch eventing %s/%s failed: %v", eventing.Name, eventing.Namespace, err)
@@ -533,7 +532,7 @@ func (env TestEnvironment) EnsureHPANotFound(t *testing.T, name, namespace strin
 }
 
 func (env TestEnvironment) EnsureEventingResourceDeletion(t *testing.T, name, namespace string) {
-	eventing := &eventingv1alpha1.Eventing{
+	eventing := &v1alpha1.Eventing{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
@@ -547,7 +546,7 @@ func (env TestEnvironment) EnsureEventingResourceDeletion(t *testing.T, name, na
 }
 
 func (env TestEnvironment) EnsureEventingResourceDeletionStateError(t *testing.T, name, namespace string) {
-	eventing := &eventingv1alpha1.Eventing{
+	eventing := &v1alpha1.Eventing{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
@@ -556,7 +555,7 @@ func (env TestEnvironment) EnsureEventingResourceDeletionStateError(t *testing.T
 	env.EnsureK8sResourceDeleted(t, eventing)
 	require.Eventually(t, func() bool {
 		err := env.k8sClient.Get(env.Context, types.NamespacedName{Name: name, Namespace: namespace}, eventing)
-		return err == nil && eventing.Status.State == eventingv1alpha1.StateError
+		return err == nil && eventing.Status.State == v1alpha1.StateError
 	}, SmallTimeOut, SmallPollingInterval, "failed to ensure deletion of Eventing")
 }
 
@@ -918,8 +917,8 @@ func getTestBackendConfig() env.BackendConfig {
 	}
 }
 
-func (env TestEnvironment) GetEventingFromK8s(name, namespace string) (*eventingv1alpha1.Eventing, error) {
-	eventing := &eventingv1alpha1.Eventing{}
+func (env TestEnvironment) GetEventingFromK8s(name, namespace string) (*v1alpha1.Eventing, error) {
+	eventing := &v1alpha1.Eventing{}
 	err := env.k8sClient.Get(env.Context, types.NamespacedName{
 		Name:      name,
 		Namespace: namespace,
@@ -928,7 +927,7 @@ func (env TestEnvironment) GetEventingFromK8s(name, namespace string) (*eventing
 }
 
 func (env TestEnvironment) DeleteEventingFromK8s(name, namespace string) error {
-	cr := &eventingv1alpha1.Eventing{
+	cr := &v1alpha1.Eventing{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,

--- a/test/utils/integration/integration.go
+++ b/test/utils/integration/integration.go
@@ -12,25 +12,23 @@ import (
 	"testing"
 	"time"
 
-	"github.com/kyma-project/eventing-manager/pkg/subscriptionmanager"
-	"github.com/kyma-project/eventing-manager/pkg/subscriptionmanager/manager"
-	submanagermocks "github.com/kyma-project/eventing-manager/pkg/subscriptionmanager/manager/mocks"
-
-	apiclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
-
-	subscriptionmanagermocks "github.com/kyma-project/eventing-manager/pkg/subscriptionmanager/mocks"
-	"github.com/stretchr/testify/mock"
-
-	corev1 "k8s.io/api/core/v1"
-	rbacv1 "k8s.io/api/rbac/v1"
-
-	"github.com/kyma-project/eventing-manager/test"
-
 	"github.com/avast/retry-go/v3"
 	"github.com/go-logr/zapr"
+	natsv1alpha1 "github.com/kyma-project/nats-manager/api/v1alpha1"
+	"github.com/kyma-project/nats-manager/testutils"
 	"github.com/onsi/gomega"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	admissionv1 "k8s.io/api/admissionregistration/v1"
+	v1 "k8s.io/api/apps/v1"
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apiclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
@@ -46,15 +44,12 @@ import (
 	"github.com/kyma-project/eventing-manager/pkg/eventing"
 	"github.com/kyma-project/eventing-manager/pkg/k8s"
 	"github.com/kyma-project/eventing-manager/pkg/logger"
+	"github.com/kyma-project/eventing-manager/pkg/subscriptionmanager"
+	"github.com/kyma-project/eventing-manager/pkg/subscriptionmanager/manager"
+	submanagermocks "github.com/kyma-project/eventing-manager/pkg/subscriptionmanager/manager/mocks"
+	subscriptionmanagermocks "github.com/kyma-project/eventing-manager/pkg/subscriptionmanager/mocks"
+	"github.com/kyma-project/eventing-manager/test"
 	evnttestutils "github.com/kyma-project/eventing-manager/test/utils"
-	natsv1alpha1 "github.com/kyma-project/nats-manager/api/v1alpha1"
-	"github.com/kyma-project/nats-manager/testutils"
-	admissionv1 "k8s.io/api/admissionregistration/v1"
-	v1 "k8s.io/api/apps/v1"
-	autoscalingv1 "k8s.io/api/autoscaling/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 )
 
 const (

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -7,16 +7,15 @@ import (
 	"reflect"
 	"time"
 
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-
 	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/kyma-project/eventing-manager/api/v1alpha1"
-	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (


### PR DESCRIPTION
The package `"github.com/kyma-project/eventing-manager/api/v1alpha1"` gets imported twice. Let's remove one import. 

And there are some import sorts.

For a good review experience just take a look at the first commit. :)