### PR TITLE
Use created-by label to cache runtime objects

### DIFF
--- a/internal/controller/cache/cache.go
+++ b/internal/controller/cache/cache.go
@@ -19,14 +19,13 @@ func New(config *rest.Config, options cache.Options) (cache.Cache, error) {
 
 // applySelectors applies label selectors to runtime objects created by the EventingManager.
 func applySelectors(options cache.Options) cache.Options {
-	//nolint:godox // TODO(marcobebway) filter by label "app.kubernetes.io/created-by=eventing-manager" when it is released
-	instanceEventing := fromLabelSelector(label.SelectorInstanceEventing())
+	createdByEventingManager := fromLabelSelector(label.SelectorCreatedByEventingManager())
 	options.ByObject = map[client.Object]cache.ByObject{
-		&kappsv1.Deployment{}:                     instanceEventing,
-		&kcorev1.ServiceAccount{}:                 instanceEventing,
-		&krbacv1.ClusterRole{}:                    instanceEventing,
-		&krbacv1.ClusterRoleBinding{}:             instanceEventing,
-		&kautoscalingv1.HorizontalPodAutoscaler{}: instanceEventing,
+		&kappsv1.Deployment{}:                     createdByEventingManager,
+		&kcorev1.ServiceAccount{}:                 createdByEventingManager,
+		&krbacv1.ClusterRole{}:                    createdByEventingManager,
+		&krbacv1.ClusterRoleBinding{}:             createdByEventingManager,
+		&kautoscalingv1.HorizontalPodAutoscaler{}: createdByEventingManager,
 	}
 	return options
 }

--- a/internal/controller/cache/cache_test.go
+++ b/internal/controller/cache/cache_test.go
@@ -20,7 +20,7 @@ func Test_applySelectors(t *testing.T) {
 	selector := cache.ByObject{
 		Label: labels.SelectorFromSet(
 			map[string]string{
-				"app.kubernetes.io/instance": "eventing",
+				"app.kubernetes.io/created-by": "eventing-manager",
 			},
 		),
 	}

--- a/internal/label/label.go
+++ b/internal/label/label.go
@@ -19,6 +19,6 @@ const (
 	ValueEventing               = "eventing"
 )
 
-func SelectorInstanceEventing() labels.Selector {
-	return labels.SelectorFromSet(map[string]string{KeyInstance: ValueEventing})
+func SelectorCreatedByEventingManager() labels.Selector {
+	return labels.SelectorFromSet(map[string]string{KeyCreatedBy: ValueEventingManager})
 }

--- a/internal/label/label_test.go
+++ b/internal/label/label_test.go
@@ -7,7 +7,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 )
 
-func TestSelectorInstanceEventing(t *testing.T) {
+func TestSelectorCreatedByEventingManager(t *testing.T) {
 	// given
 	tests := []struct {
 		name string
@@ -17,7 +17,7 @@ func TestSelectorInstanceEventing(t *testing.T) {
 			name: "should return the correct selector",
 			want: labels.SelectorFromSet(
 				map[string]string{
-					"app.kubernetes.io/instance": "eventing",
+					"app.kubernetes.io/created-by": "eventing-manager",
 				},
 			),
 		},
@@ -25,7 +25,7 @@ func TestSelectorInstanceEventing(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// when
-			got := SelectorInstanceEventing()
+			got := SelectorCreatedByEventingManager()
 
 			// then
 			require.Equal(t, tt.want, got)


### PR DESCRIPTION
**Description**

Use the `app.kubernetes.io/created-by` label to cache runtime objects.

⚠️ Caution ⚠️

This PR should be merged only after the label `app.kubernetes.io/created-by=eventing-manager` is released to PROD.