### PR TITLE
Update UI with improved notifications

### DIFF
--- a/config/samples/empty_backend.yaml
+++ b/config/samples/empty_backend.yaml
@@ -1,0 +1,22 @@
+apiVersion: operator.kyma-project.io/v1alpha1
+kind: Eventing
+metadata:
+  labels:
+    app.kubernetes.io/name: eventing
+    app.kubernetes.io/instance: eventing
+    app.kubernetes.io/part-of: eventing-manager
+    app.kubernetes.io/created-by: eventing-manager
+  name: eventing
+  namespace: kyma-system
+spec:
+  publisher:
+    replicas:
+      min: 2
+      max: 2
+    resources:
+      limits:
+        cpu: 500m
+        memory: 512Mi
+      requests:
+        cpu: 40m
+        memory: 64Mi

--- a/config/ui-extensions/eventing/details
+++ b/config/ui-extensions/eventing/details
@@ -28,11 +28,11 @@ body:
   - source: "'NATS unavailable: If you chose the NATS backend, you must enable the NATS module.'"
     widget: Alert
     severity: warning
-    visibility: "$status.conditions[reason = 'NATSUnavailable'] and $status.state = 'Warning'"
+    visibility: "$exists(status.conditions[reason = 'NATSUnavailable'])"
   - source: "'No backend: If you enable the Eventing module, you must configure a backend.'"
     widget: Alert
     severity: warning
-    visibility: "$status.conditions[reason = 'BackendNotSpecified'] and $status.state = 'Warning'"
+    visibility: "$exists(status.conditions[reason = 'BackendNotSpecified'])"
   - name: Events
     widget: EventList
     filter: '$matchEvents($$, $root.kind, $root.metadata.name)'

--- a/config/ui-extensions/eventing/details
+++ b/config/ui-extensions/eventing/details
@@ -4,10 +4,6 @@ header:
     widget: Badge
 
 body:
-  - source: "'If you chose the NATS backend, you must enable the NATS module.'"
-    widget: Alert
-    severity: info
-    visibility: "status.state = 'Warning'"
   - name: Conditions
     source: status.conditions
     widget: Table
@@ -29,10 +25,10 @@ body:
       - source: '$readableTimestamp(lastTransitionTime)'
         name: Last transition
         sort: true
-  - source: "'If you choose the NATS backend, you must enable the NATS module.'"
+  - source: "'NATS unavailable: If you choose the NATS backend, you must enable the NATS module.'"
     widget: Alert
-    severity: info
-    visibility: "status.conditions.reason = 'NATSUnavailable'"
+    severity: warning
+    visibility: "$status.conditions[reason = 'NATSUnavailable']"
   - name: Events
     widget: EventList
     filter: '$matchEvents($$, $root.kind, $root.metadata.name)'

--- a/config/ui-extensions/eventing/details
+++ b/config/ui-extensions/eventing/details
@@ -4,6 +4,10 @@ header:
     widget: Badge
 
 body:
+  - source: "'If you chose the NATS backend, you must enable the NATS module.'"
+    widget: Alert
+    severity: info
+    visibility: "status.state = 'Warning'"
   - name: Conditions
     source: status.conditions
     widget: Table
@@ -25,6 +29,10 @@ body:
       - source: '$readableTimestamp(lastTransitionTime)'
         name: Last transition
         sort: true
+  - source: "'If you choose the NATS backend, you must enable the NATS module.'"
+    widget: Alert
+    severity: info
+    visibility: "status.conditions.reason = 'NATSUnavailable'"
   - name: Events
     widget: EventList
     filter: '$matchEvents($$, $root.kind, $root.metadata.name)'

--- a/config/ui-extensions/eventing/details
+++ b/config/ui-extensions/eventing/details
@@ -25,10 +25,14 @@ body:
       - source: '$readableTimestamp(lastTransitionTime)'
         name: Last transition
         sort: true
-  - source: "'NATS unavailable: If you choose the NATS backend, you must enable the NATS module.'"
+  - source: "'NATS unavailable: If you chose the NATS backend, you must enable the NATS module.'"
     widget: Alert
     severity: warning
-    visibility: "$status.conditions[reason = 'NATSUnavailable']"
+    visibility: "$status.conditions[reason = 'NATSUnavailable'] and $status.state = 'Warning'"
+  - source: "'No backend: If you enable the Eventing module, you must configure a backend.'"
+    widget: Alert
+    severity: warning
+    visibility: "$status.conditions[reason = 'BackendNotSpecified'] and $status.state = 'Warning'"
   - name: Events
     widget: EventList
     filter: '$matchEvents($$, $root.kind, $root.metadata.name)'

--- a/config/ui-extensions/eventing/form
+++ b/config/ui-extensions/eventing/form
@@ -7,6 +7,12 @@
     - EventMesh
   description: Choose a backend type from the dropdown.
 
+- simple: true
+  widget: Alert
+  severity: info
+  alert: "'If you choose the NATS backend, you must enable the NATS module.'"
+  visibility: "spec.backend.type = 'NATS'"
+
 - path: spec.backend.config.eventMeshSecret
   visibility: "spec.backend.type = 'EventMesh'"
   widget: ResourceRef

--- a/config/ui-extensions/eventing/kustomization.yaml
+++ b/config/ui-extensions/eventing/kustomization.yaml
@@ -1,6 +1,6 @@
 configMapGenerator:
   - name: eventings.operator.kyma-project.io
-    namespace: kube-public
+    namespace: kyma-system
     files:
       - general
       - form


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- [x] Selecting the nats-backend option via Busola displays a notification that requires the user to activate the nats module.
- [x] Having no backend selected displays a notification that requires the user to configure a backend.
- [x] Once a backend is selected, all modules are installed and the Eventing module is ready, no notifications are displayed.
- [ ] In the overview, if the Eventing module is in `warning` state, a notification points to the docu/error messages.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
#266 