### PR TITLE
remove reference to old publisher proxy service from documentation

### DIFF
--- a/docs/user/tutorials/evnt-02-subs-with-multiple-filters.md
+++ b/docs/user/tutorials/evnt-02-subs-with-multiple-filters.md
@@ -73,7 +73,7 @@ In the following example, you port-forward the [Event Publisher Proxy](../evnt-a
 
 1. Port-forward the [Event Publisher Proxy](../evnt-architecture.md) Service to localhost, using port `3000`. Run:
    ```bash
-   kubectl -n kyma-system port-forward service/eventing-event-publisher-proxy 3000:80
+   kubectl -n kyma-system port-forward service/eventing-publisher-proxy 3000:80
    ```
 2. Publish an event of type `order.received.v1` to trigger your Function. In another terminal window, run:
 

--- a/docs/user/tutorials/evnt-03-type-cleanup.md
+++ b/docs/user/tutorials/evnt-03-type-cleanup.md
@@ -131,7 +131,7 @@ Next, you see that you can still publish events with the original Event name (i.
 
 1. Port-forward the [Event Publisher Proxy](../evnt-architecture.md) Service to localhost, using port `3000`. Run:
    ```bash
-   kubectl -n kyma-system port-forward service/eventing-event-publisher-proxy 3000:80
+   kubectl -n kyma-system port-forward service/eventing-publisher-proxy 3000:80
    ```
 2. Publish an event to trigger your Function. In another terminal window, run:
 

--- a/docs/user/tutorials/evnt-04-change-max-in-flight-in-sub.md
+++ b/docs/user/tutorials/evnt-04-change-max-in-flight-in-sub.md
@@ -131,7 +131,7 @@ Next, publish 15 events at once and see how Kyma Eventing triggers the workload.
 
 1. Port-forward the [Event Publisher Proxy](../evnt-architecture.md) Service to localhost, using port `3000`. Run:
    ```bash
-   kubectl -n kyma-system port-forward service/eventing-event-publisher-proxy 3000:80
+   kubectl -n kyma-system port-forward service/eventing-publisher-proxy 3000:80
    ```
 2. Now publish 15 events to the Event Publisher Proxy Service. In another terminal window, run:
 

--- a/docs/user/tutorials/evnt-05-send-legacy-events.md
+++ b/docs/user/tutorials/evnt-05-send-legacy-events.md
@@ -71,7 +71,7 @@ You created the `lastorder` Function, and subscribed to the `order.received.v1` 
 
 1. Port-forward the [Event Publisher Proxy](../evnt-architecture.md) Service to localhost, using port `3000`. Run:
    ```bash
-   kubectl -n kyma-system port-forward service/eventing-event-publisher-proxy 3000:80
+   kubectl -n kyma-system port-forward service/eventing-publisher-proxy 3000:80
    ```
 2. Publish an event to trigger your Function. In another terminal window, run:
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- the old service provided by the eventing-component was still used in the documentation for the eventing-module

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
