### PR TITLE
Improve Prow job verification script

### DIFF
--- a/scripts/verify-status.sh
+++ b/scripts/verify-status.sh
@@ -3,15 +3,28 @@
 echo "Checking status of POST Jobs for Eventing-Manager"
 
 REF_NAME="${1:-"main"}"
+# Generate job Status URL
 STATUS_URL="https://api.github.com/repos/kyma-project/eventing-manager/commits/${REF_NAME}/status"
-fullstatus=`curl -L -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" ${STATUS_URL} | head -n 2 `
 
-sleep 10
+# Wait for job result 
+sleep 30
+
+# Get status result
+statusresult=`curl -L -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" ${STATUS_URL}`
+# Get overall state
+fullstatus=$(echo $statusresult | jq  '.state' | tr -d '"')
+
+# Show overall state to user
 echo $fullstatus
 
-if [[ "$fullstatus" == *"success"* ]]; then
+# Check state
+if [[ $fullstatus == "success" ]]; then
+  # Job: success
   echo "All jobs succeeded"
 else
+  # Job: failed or pending
   echo "Jobs failed or pending - Check Prow status"
+  # Show job(s) details
+  echo $statusresult | jq '.statuses[]' 
   exit 1
 fi


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

-We were facing the following issue during Prow job verification:

```bash
curl: (23) Failed writing body
{ "state": "pending",
Jobs failed or pending - Check Prow status
Error: Process completed with exit code 1.
```
- Then we realized the status API was called immediately after the starting, therefore the state will be Faliled or Pending every time.
- Added some extra output and parse the results with `jq`

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
