### PR TITLE
Improve Prow job verification script

### DIFF
--- a/scripts/check_image.sh
+++ b/scripts/check_image.sh
@@ -1,11 +1,9 @@
 #!/usr/bin/env bash
 
 REF_NAME="${1:-"main"}"
-
-#SHORT_EXPECTED_SHA=$(git rev-parse --short=8 "${REF_NAME}~")
-#DATE="v$(git show ${SHORT_EXPECTED_SHA} --date=format:'%Y%m%d' --format=%ad -q)"
-
-EXPECTED_TAG="${REF_NAME}"
+SHORT_EXPECTED_SHA=$(git rev-parse --short=8 "${REF_NAME}~")
+DATE="v$(git show ${SHORT_EXPECTED_SHA} --date=format:'%Y%m%d' --format=%ad -q)"
+EXPECTED_TAG="${DATE}-${SHORT_EXPECTED_SHA}"
 
 IMAGE_TO_CHECK="${2:-europe-docker.pkg.dev/kyma-project/prod/eventing-manager}"
 BUMPED_IMAGE_TAG=$(cat sec-scanners-config.yaml | grep "${IMAGE_TO_CHECK}" | cut -d : -f 2)

--- a/sec-scanners-config.yaml
+++ b/sec-scanners-config.yaml
@@ -1,7 +1,7 @@
 module-name: eventing
 rc-tag: 0.0.0
 protecode:
-  - europe-docker.pkg.dev/kyma-project/prod/eventing-manager:0.0.0
+  - europe-docker.pkg.dev/kyma-project/prod/eventing-manager:v20231207-c940762f
   - europe-docker.pkg.dev/kyma-project/prod/event-publisher-proxy:v20231025-3f5d1600
   - europe-docker.pkg.dev/kyma-project/prod/eventing-webhook-certificates:1.7.0
 whitesource:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

-We were facing the following issue during Prow job verification:

```bash
curl: (23) Failed writing body
{ "state": "pending",
Jobs failed or pending - Check Prow status
Error: Process completed with exit code 1.
```
- Then we realized the status API was called immediately after the starting, therefore the state will be Faliled or Pending every time.
- Added some extra output and parse the results with `jq`

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
