### PR TITLE
Improve EventMesh Tests for Better error comparison

### DIFF
--- a/internal/controller/operator/eventing/eventmesh.go
+++ b/internal/controller/operator/eventing/eventmesh.go
@@ -50,13 +50,13 @@ func (r *Reconciler) reconcileEventMeshSubManager(ctx context.Context, eventing 
 	// gets oauth2ClientID and secret and stops the EventMesh subscription manager if changed
 	err := r.syncOauth2ClientIDAndSecret(ctx, eventing)
 	if err != nil {
-		return fmt.Errorf("failed to sync OAuth secret: %v", err)
+		return fmt.Errorf("failed to sync OAuth secret: %w", err)
 	}
 
 	// CreateOrUpdate deployment for publisher proxy secret
 	secretForPublisher, err := r.SyncPublisherProxySecret(ctx, eventMeshSecret)
 	if err != nil {
-		return fmt.Errorf("failed to sync Publisher Proxy secret: %v", err)
+		return fmt.Errorf("failed to sync Publisher Proxy secret: %w", err)
 	}
 
 	// Set environment with secrets for EventMesh subscription controller

--- a/internal/controller/operator/eventing/eventmesh_test.go
+++ b/internal/controller/operator/eventing/eventmesh_test.go
@@ -97,7 +97,7 @@ func Test_reconcileEventMeshSubManager(t *testing.T) {
 			givenKubeClientMock: func() k8s.Client {
 				mockKubeClient := new(k8smocks.Client)
 				mockKubeClient.On("GetSecret", ctx, mock.Anything, mock.Anything).Return(
-					nil, errors.New("secret not found")).Once()
+					nil, fmt.Errorf("secret not found")).Once()
 				return mockKubeClient
 			},
 			wantError:     fmt.Errorf("failed to sync OAuth secret: secret not found"),
@@ -769,7 +769,7 @@ func Test_getOAuth2ClientCredentials(t *testing.T) {
 
 			kubeClient := new(k8smocks.Client)
 
-			notFoundErr := errors.New("secret not found")
+			notFoundErr := fmt.Errorf("secret not found")
 			if tc.givenSecret != nil {
 				kubeClient.On("GetSecret", mock.Anything, mock.Anything).Return(tc.givenSecret, nil).Once()
 			} else {


### PR DESCRIPTION

**Description**
Improve EventMesh tests

Changes proposed in this pull request:
- Don't use require.ErrorAs as it only compares types. Instead error should be compared properly.
- Change business logic to make it mockable

**Related issue(s)**
[#334](https://github.com/kyma-project/eventing-manager/issues/334)