### PR TITLE
Cheery-pick: fix release of manifests (#340)

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -32,11 +32,6 @@ jobs:
       - name: Check image Tag
         run: ./scripts/check_tag_info.sh ${{ github.event.inputs.name }}
 
-        #  run-unit-tests:
-        #    name: Unit tests
-        #    needs: verify-head-status
-        #    uses: "./.github/workflows/run-unit-tests.yaml"
-
   create-draft:
     name: Create draft release
     needs: verify-head-status
@@ -69,13 +64,15 @@ jobs:
       - name: Verify job status
         run: ./scripts/verify-status.sh ${{ github.ref_name }} 600 10 30
 
+      - name: Create and upload eventing-manager.yaml and eventing-default-cr.yaml
+        env:
+          PULL_BASE_REF: ${{ PULL_BASE_REF }}
+          BOT_GITHUB_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
+        run: |
+          ./scripts/render_and_upload_manifests.sh ${{ PULL_BASE_REF }} ${{ BOT_GITHUB_TOKEN }}
+
     outputs:
       release_id: ${{ steps.create-draft.outputs.release_id }}
-
-  # devOps-Insights:
-  #   name: DevOps Insights
-  #   needs: [verify-head-status, create-draft, run-unit-tests]
-  #   uses: "./.github/workflows/metrics.yaml"
 
   publish-release:
     name: Publish release

--- a/scripts/render_and_upload_manifests.sh
+++ b/scripts/render_and_upload_manifests.sh
@@ -11,23 +11,23 @@ set -o pipefail # prevents errors in a pipeline from being masked
 #   BOT_GITHUB_TOKEN - github token used to upload the template yaml
 
 uploadFile() {
-  filePath=${1}
-  ghAsset=${2}
+	filePath=${1}
+	ghAsset=${2}
 
-  echo "Uploading ${filePath} as ${ghAsset}"
-  response=$(curl -s -o output.txt -w "%{http_code}" \
-                  --request POST --data-binary @"$filePath" \
-                  -H "Authorization: token $BOT_GITHUB_TOKEN" \
-                  -H "Content-Type: text/yaml" \
-                  $ghAsset)
-  if [[ "$response" != "201" ]]; then
-    echo "Unable to upload the asset ($filePath): "
-    echo "HTTP Status: $response"
-    cat output.txt
-    exit 1
-  else
-    echo "$filePath uploaded"
-  fi
+	echo "Uploading ${filePath} as ${ghAsset}"
+	response=$(curl -s -o output.txt -w "%{http_code}" \
+		--request POST --data-binary @"$filePath" \
+		-H "Authorization: token $BOT_GITHUB_TOKEN" \
+		-H "Content-Type: text/yaml" \
+		$ghAsset)
+	if [[ "$response" != "201" ]]; then
+		echo "Unable to upload the asset ($filePath): "
+		echo "HTTP Status: $response"
+		cat output.txt
+		exit 1
+	else
+		echo "$filePath uploaded"
+	fi
 }
 
 echo "PULL_BASE_REF ${PULL_BASE_REF}"
@@ -39,33 +39,34 @@ cat eventing-manager.yaml
 
 MODULE_VERSION=${PULL_BASE_REF} make module-build
 
-echo "Generated moduletemplate.yaml:"
-cat module-template.yaml
+# TODO completly remove the rendering of the module-template from the repository.
+# echo "Generated moduletemplate.yaml:"
+# cat module-template.yaml
 
 echo "Updating github release with eventing-manager.yaml"
 
 echo "Finding release id for: ${PULL_BASE_REF}"
 CURL_RESPONSE=$(curl -w "%{http_code}" -sL \
-                -H "Accept: application/vnd.github+json" \
-                -H "Authorization: Bearer $BOT_GITHUB_TOKEN" \
-                https://api.github.com/repos/kyma-project/eventing-manager/releases)
-JSON_RESPONSE=$(sed '$ d' <<< "${CURL_RESPONSE}")
-HTTP_CODE=$(tail -n1 <<< "${CURL_RESPONSE}")
+	-H "Accept: application/vnd.github+json" \
+	-H "Authorization: Bearer $BOT_GITHUB_TOKEN" \
+	https://api.github.com/repos/kyma-project/eventing-manager/releases)
+JSON_RESPONSE=$(sed '$ d' <<<"${CURL_RESPONSE}")
+HTTP_CODE=$(tail -n1 <<<"${CURL_RESPONSE}")
 if [[ "${HTTP_CODE}" != "200" ]]; then
-  echo "${JSON_RESPONSE}" && exit 1
+	echo "${JSON_RESPONSE}" && exit 1
 fi
 
 echo "Finding release id for: ${PULL_BASE_REF}"
 RELEASE_ID=$(jq <<<${JSON_RESPONSE} --arg tag "${PULL_BASE_REF}" '.[] | select(.tag_name == $ARGS.named.tag) | .id')
 
-if [ -z "${RELEASE_ID}" ]
-then
-  echo "No release with tag = ${PULL_BASE_REF}"
-  exit 1
+if [ -z "${RELEASE_ID}" ]; then
+	echo "No release with tag = ${PULL_BASE_REF}"
+	exit 1
 fi
 
 UPLOAD_URL="https://uploads.github.com/repos/kyma-project/eventing-manager/releases/${RELEASE_ID}/assets"
 
 uploadFile "eventing-manager.yaml" "${UPLOAD_URL}?name=eventing-manager.yaml"
-uploadFile "module-template.yaml" "${UPLOAD_URL}?name=module-template.yaml"
+# TODO completly remove the rendering of the module-template from the repository.
+# uploadFile "module-template.yaml" "${UPLOAD_URL}?name=module-template.yaml"
 uploadFile "config/samples/default.yaml" "${UPLOAD_URL}?name=eventing_default_cr.yaml"


### PR DESCRIPTION
* clean up create-release.yml

Clean up the create-release.yml by removing a number of unused and outcommented lines.

* rename release.sh to render_and_upload_manifests.sh

Rename the scripts/release.sh to render_and_upload_manifests.sh to point clearly out, what the script is about.

* call manifest release from create-release.yml

Call the render_and_upload_manifests.sh because it no longer created by a prow job.

* deactivate module-template upload

Deactivate the upload of the module-template. All functionality for the module-template will be removed eventually, in a follow up PR.

* fix reference of env var

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Cherry-pick the changes done to `create release` to the `release-1.0` branch.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
