### PR TITLE
remove call of make module-build

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -69,7 +69,6 @@ jobs:
           PULL_BASE_REF: ${{ github.event.input.name }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           IMG: "europe-docker.pkg.dev/kyma-project/prod/eventing-manager:${{ github.event.input.name }}"
-          MODULE_REGISTRY: "europe-docker.pkg.dev/kyma-project/prod/unsigned"
           KUSTOMIZE_VERSION: "v4.5.6"
         run: |
           ./scripts/render_and_upload_manifests.sh

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -69,6 +69,7 @@ jobs:
           PULL_BASE_REF: ${{ github.event.input.name }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           IMG: "europe-docker.pkg.dev/kyma-project/prod/eventing-manager:${{ github.event.input.name }}"
+          MODULE_REGISTRY: "europe-docker.pkg.dev/kyma-project/prod/unsigned"
           KUSTOMIZE_VERSION: "v4.5.6"
         run: |
           ./scripts/render_and_upload_manifests.sh

--- a/scripts/render_and_upload_manifests.sh
+++ b/scripts/render_and_upload_manifests.sh
@@ -37,8 +37,7 @@ MODULE_VERSION=${PULL_BASE_REF} make render-manifest
 echo "Generated eventing-manager.yaml:"
 cat eventing-manager.yaml
 
-MODULE_VERSION=${PULL_BASE_REF} make module-build
-
+# MODULE_VERSION=${PULL_BASE_REF} make module-build
 # TODO completly remove the rendering of the module-template from the repository.
 # echo "Generated moduletemplate.yaml:"
 # cat module-template.yaml


### PR DESCRIPTION
We really only need to render the manifests so lets remove module-build.

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

in the release action, we do not need make build module, so let's remove it.

Changes proposed in this pull request:

- remove `make build-module`

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
