### PR TITLE
Remove lifecycle manager names from jobs

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,4 +1,4 @@
-name: e2e-without-lifecycle-manager
+name: e2e-test
 
 env:
   KYMA_STABILITY: "unstable"


### PR DESCRIPTION
**Description**
Remove lifecycle manager names from jobs as by default KLM is not used anymore for the tests

**Related issue(s)**
https://github.com/kyma-project/nats-manager/issues/228
