### PR TITLE
Release without version input

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Create and upload eventing-manager.yaml and eventing-default-cr.yaml
         env:
           PULL_BASE_REF: ${{ github.event.input.name }}
-          BOT_GITHUB_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           IMG: "europe-docker.pkg.dev/kyma-project/prod/eventing-manager:${{ github.event.input.name }}"
           MODULE_REGISTRY: "europe-docker.pkg.dev/kyma-project/prod/unsigned"
           KUSTOMIZE_VERSION: "v4.5.6"

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Check image Tag
         env:
           VERSION: ${{ steps.gen-version.outputs.VERSION }}
-        run: ./scripts/check_tag_info.sh $VERSION
+        run: ./scripts/check_sec-scanners-config.sh $VERSION
 
   create-draft:
     name: Create draft release

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -66,10 +66,10 @@ jobs:
 
       - name: Create and upload eventing-manager.yaml and eventing-default-cr.yaml
         env:
-          PULL_BASE_REF: ${{ PULL_BASE_REF }}
+          PULL_BASE_REF: ${{ github.event.input.name }}
           BOT_GITHUB_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
         run: |
-          ./scripts/render_and_upload_manifests.sh ${{ PULL_BASE_REF }} ${{ BOT_GITHUB_TOKEN }}
+          ./scripts/render_and_upload_manifests.sh
 
     outputs:
       release_id: ${{ steps.create-draft.outputs.release_id }}

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -2,15 +2,10 @@ name: "Create release"
 
 on:
   workflow_dispatch:
-    inputs:
-      name:
-        description: 'Release name ( e.g. "2.1.3" )'
-        default: ""
-        required: true
 
 jobs:
-  verify-head-status:
-    name: Verify head (image version and prow job)
+  verify-release:
+    name: Verify release
     runs-on: ubuntu-latest
 
     steps:
@@ -19,23 +14,28 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Verify that the current branch has a name that starts with 'release-'
+      - name: Generate version number
+        id: version
         run: |
-          CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
-          if [[ "$CURRENT_BRANCH" == release-* ]]; then
-            echo "Branch name starts with 'release-'."
-          else
-            echo "Branch name does not start with 'release-'."
-            exit 1
-          fi
+          GET_VERSION=$(mktemp /tmp/get-version-from-branch.sh)
+          curl -L https://raw.githubusercontent.com/kyma-project/eventing-tools/main/hack/scripts/get-version-from-branch.sh -o "${GET_VERSION}"
+          chmod +x "${GET_VERSION}"
+          VERSION="${GET_VERSION}"
+          echo "::set-output name=version::$version"
 
       - name: Check image Tag
-        run: ./scripts/check_tag_info.sh ${{ github.event.inputs.name }}
+        env:
+          VERSION: ${{ steps.gen-version.outputs.VERSION }}
+        run: ./scripts/check_tag_info.sh $VERSION
 
   create-draft:
     name: Create draft release
     needs: verify-head-status
     runs-on: ubuntu-latest
+    env:
+      VERSION: ${{ needs.verify-release.outputs.VERSION }}
+    outputs:
+      release_id: ${{ steps.create-draft.outputs.release_id }}
 
     steps:
       - name: Checkout code
@@ -46,36 +46,33 @@ jobs:
       - name: Create changelog
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: ./scripts/create_changelog.sh ${{ github.event.inputs.name }}
+        run: ./scripts/create_changelog.sh $VERSION
 
       - name: Create draft release
         id: create-draft
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          RELEASE_ID=$(./scripts/create_draft_release.sh ${{ github.event.inputs.name }})
+          RELEASE_ID=$(./scripts/create_draft_release.sh $VERSION
           echo "release_id=$RELEASE_ID" >> $GITHUB_OUTPUT
 
       - name: Create lightweight tag
         run: |
-          git tag ${{ github.event.inputs.name }}
-          git push origin ${{ github.event.inputs.name }}
+          git tag $VERSION
+          git push origin $VERSION
 
       - name: Verify job status
         run: ./scripts/verify-status.sh ${{ github.ref_name }} 600 10 30
 
       - name: Create and upload eventing-manager.yaml and eventing-default-cr.yaml
         env:
-          PULL_BASE_REF: ${{ github.event.inputs.name }}
+          PULL_BASE_REF: $VERSION
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          IMG: "europe-docker.pkg.dev/kyma-project/prod/eventing-manager:${{ github.event.inputs.name }}"
+          IMG: "europe-docker.pkg.dev/kyma-project/prod/eventing-manager:${VERSION}"
           MODULE_REGISTRY: "europe-docker.pkg.dev/kyma-project/prod/unsigned"
           KUSTOMIZE_VERSION: "v4.5.6"
         run: |
           ./scripts/render_and_upload_manifests.sh
-
-    outputs:
-      release_id: ${{ steps.create-draft.outputs.release_id }}
 
   publish-release:
     name: Publish release

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -68,6 +68,9 @@ jobs:
         env:
           PULL_BASE_REF: ${{ github.event.input.name }}
           BOT_GITHUB_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
+          IMG: "europe-docker.pkg.dev/kyma-project/prod/eventing-manager:${{ github.event.input.name }}"
+          MODULE_REGISTRY: "europe-docker.pkg.dev/kyma-project/prod/unsigned"
+          KUSTOMIZE_VERSION: "v4.5.6"
         run: |
           ./scripts/render_and_upload_manifests.sh
 

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -7,6 +7,8 @@ jobs:
   verify-release:
     name: Verify release
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.gen-version.outputs.VERSION }}
 
     steps:
       - name: Checkout code
@@ -15,13 +17,16 @@ jobs:
           fetch-depth: 0
 
       - name: Generate version number
-        id: version
+        id: gen-version
         run: |
-          GET_VERSION=$(mktemp /tmp/get-version-from-branch.sh)
+          # get script
+          GET_VERSION=$(mktemp /tmp/get-version-from-branch.XXXXX)
           curl -L https://raw.githubusercontent.com/kyma-project/eventing-tools/main/hack/scripts/get-version-from-branch.sh -o "${GET_VERSION}"
           chmod +x "${GET_VERSION}"
-          VERSION="${GET_VERSION}"
-          echo "::set-output name=version::$version"
+          # get version via script
+          VERSION=$("${GET_VERSION}")
+          # push version to output environment file
+          echo "VERSION=${VERSION}" >> $GITHUB_OUTPUT
 
       - name: Check image Tag
         env:

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -66,13 +66,10 @@ jobs:
 
       - name: Create and upload eventing-manager.yaml and eventing-default-cr.yaml
         env:
-          PULL_BASE_REF: ${{ github.event.inputs.name }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          IMG: "europe-docker.pkg.dev/kyma-project/prod/eventing-manager:${{ github.event.inputs.name }}"
-          MODULE_REGISTRY: "europe-docker.pkg.dev/kyma-project/prod/unsigned"
-          KUSTOMIZE_VERSION: "v4.5.6"
+          PULL_BASE_REF: ${{ PULL_BASE_REF }}
+          BOT_GITHUB_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
         run: |
-          ./scripts/render_and_upload_manifests.sh
+          ./scripts/render_and_upload_manifests.sh ${{ PULL_BASE_REF }} ${{ BOT_GITHUB_TOKEN }}
 
     outputs:
       release_id: ${{ steps.create-draft.outputs.release_id }}

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -66,9 +66,9 @@ jobs:
 
       - name: Create and upload eventing-manager.yaml and eventing-default-cr.yaml
         env:
-          PULL_BASE_REF: ${{ github.event.input.name }}
+          PULL_BASE_REF: ${{ github.event.inputs.name }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          IMG: "europe-docker.pkg.dev/kyma-project/prod/eventing-manager:${{ github.event.input.name }}"
+          IMG: "europe-docker.pkg.dev/kyma-project/prod/eventing-manager:${{ github.event.inputs.name }}"
           MODULE_REGISTRY: "europe-docker.pkg.dev/kyma-project/prod/unsigned"
           KUSTOMIZE_VERSION: "v4.5.6"
         run: |

--- a/scripts/check_sec-scanners-config.sh
+++ b/scripts/check_sec-scanners-config.sh
@@ -1,10 +1,12 @@
 #!/usr/bin/env bash
 
-##############################
-# Check tags in security-scan-config.yaml
-# Image Tag, rc-tag
-##############################
+# This script checks thate the RC-Tag and the eventing-manager image have the tag of the corresponding release.
 
+# Error handling:
+set -o nounset  # treat unset variables as an error and exit immediately.
+set -o errexit  # exit immediately when a command fails.
+set -E          # needs to be set if we want the ERR trap
+set -o pipefail # prevents errors in a pipeline from being masked
 
 # Get release version
 DESIRED_TAG="${1:-"main"}"
@@ -19,12 +21,12 @@ RC_TAG=$(cat sec-scanners-config.yaml | grep "${RC_TAG_TO_CHECK}" | cut -d : -f 
 
 # Check IMAGE_TAG and required image tag
 if [[ "$IMAGE_TAG" != "$DESIRED_TAG" ]] || [[ "$RC_TAG" != "$DESIRED_TAG" ]]; then
-  # ERROR: Tag issue
-  echo "Tags are not correct:
+	# ERROR: Tag issue
+	echo "Tags are not correct:
   - wanted: $DESIRED_TAG
   - security-scanner image tag: $IMAGE_TAG
   - rc-tag: $RC_TAG"
-  exit 1
+	exit 1
 fi
 
 # OK: Everything is fine

--- a/scripts/render_and_upload_manifests.sh
+++ b/scripts/render_and_upload_manifests.sh
@@ -37,8 +37,7 @@ MODULE_VERSION=${PULL_BASE_REF} make render-manifest
 echo "Generated eventing-manager.yaml:"
 cat eventing-manager.yaml
 
-MODULE_VERSION=${PULL_BASE_REF} make module-build
-
+# MODULE_VERSION=${PULL_BASE_REF} make module-build
 # TODO completly remove the rendering of the module-template from the repository.
 # echo "Generated moduletemplate.yaml:"
 # cat module-template.yaml

--- a/scripts/render_and_upload_manifests.sh
+++ b/scripts/render_and_upload_manifests.sh
@@ -8,7 +8,7 @@ set -o pipefail # prevents errors in a pipeline from being masked
 
 # Expected variables:
 #   PULL_BASE_REF - name of the tag
-#   GITHUB_TOKEN - github token used to upload the template yaml
+#   BOT_GITHUB_TOKEN - github token used to upload the template yaml
 
 uploadFile() {
 	filePath=${1}
@@ -17,7 +17,7 @@ uploadFile() {
 	echo "Uploading ${filePath} as ${ghAsset}"
 	response=$(curl -s -o output.txt -w "%{http_code}" \
 		--request POST --data-binary @"$filePath" \
-		-H "Authorization: token $GITHUB_TOKEN" \
+		-H "Authorization: token $BOT_GITHUB_TOKEN" \
 		-H "Content-Type: text/yaml" \
 		$ghAsset)
 	if [[ "$response" != "201" ]]; then
@@ -37,7 +37,8 @@ MODULE_VERSION=${PULL_BASE_REF} make render-manifest
 echo "Generated eventing-manager.yaml:"
 cat eventing-manager.yaml
 
-# MODULE_VERSION=${PULL_BASE_REF} make module-build
+MODULE_VERSION=${PULL_BASE_REF} make module-build
+
 # TODO completly remove the rendering of the module-template from the repository.
 # echo "Generated moduletemplate.yaml:"
 # cat module-template.yaml
@@ -47,7 +48,7 @@ echo "Updating github release with eventing-manager.yaml"
 echo "Finding release id for: ${PULL_BASE_REF}"
 CURL_RESPONSE=$(curl -w "%{http_code}" -sL \
 	-H "Accept: application/vnd.github+json" \
-	-H "Authorization: Bearer $GITHUB_TOKEN" \
+	-H "Authorization: Bearer $BOT_GITHUB_TOKEN" \
 	https://api.github.com/repos/kyma-project/eventing-manager/releases)
 JSON_RESPONSE=$(sed '$ d' <<<"${CURL_RESPONSE}")
 HTTP_CODE=$(tail -n1 <<<"${CURL_RESPONSE}")

--- a/scripts/render_and_upload_manifests.sh
+++ b/scripts/render_and_upload_manifests.sh
@@ -8,7 +8,7 @@ set -o pipefail # prevents errors in a pipeline from being masked
 
 # Expected variables:
 #   PULL_BASE_REF - name of the tag
-#   BOT_GITHUB_TOKEN - github token used to upload the template yaml
+#   GITHUB_TOKEN - github token used to upload the template yaml
 
 uploadFile() {
 	filePath=${1}
@@ -17,7 +17,7 @@ uploadFile() {
 	echo "Uploading ${filePath} as ${ghAsset}"
 	response=$(curl -s -o output.txt -w "%{http_code}" \
 		--request POST --data-binary @"$filePath" \
-		-H "Authorization: token $BOT_GITHUB_TOKEN" \
+		-H "Authorization: token $GITHUB_TOKEN" \
 		-H "Content-Type: text/yaml" \
 		$ghAsset)
 	if [[ "$response" != "201" ]]; then
@@ -48,7 +48,7 @@ echo "Updating github release with eventing-manager.yaml"
 echo "Finding release id for: ${PULL_BASE_REF}"
 CURL_RESPONSE=$(curl -w "%{http_code}" -sL \
 	-H "Accept: application/vnd.github+json" \
-	-H "Authorization: Bearer $BOT_GITHUB_TOKEN" \
+	-H "Authorization: Bearer $GITHUB_TOKEN" \
 	https://api.github.com/repos/kyma-project/eventing-manager/releases)
 JSON_RESPONSE=$(sed '$ d' <<<"${CURL_RESPONSE}")
 HTTP_CODE=$(tail -n1 <<<"${CURL_RESPONSE}")


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md)
-->

**Description**

Changes proposed in this pull request:

Creating a release will no longer require manual input of a version number; the version number will get generated automatically.

- use [script](script](https://raw.githubusercontent.com/kyma-project/eventing-tools/main/hack/scripts/get-version-from-branch.sh)) to generate release version
- renamed script `check_tag_info.sh` to `scripts/check_sec-scanners-config.sh` for [consistent naming](https://github.com/kyma-project/nats-manager/blob/main/.github/scripts/check_sec-scanners-config.sh) between repos.

For the lack of a better method, this was conceptually tested [here](https://github.com/friedrichwilken/test-gha/actions/runs/7531147017/job/20499066155) based on [this workflow](https://github.com/friedrichwilken/test-gha/blob/release-1.0/.github/workflows/test-downloaded-script.yaml).

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
https://github.com/kyma-project/eventing-manager/issues/360
