### PR TITLE
Cherry-pick to `release-1.0`: Release without version input (#396)

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -2,16 +2,13 @@ name: "Create release"
 
 on:
   workflow_dispatch:
-    inputs:
-      name:
-        description: 'Release name ( e.g. "2.1.3" )'
-        default: ""
-        required: true
 
 jobs:
-  verify-head-status:
-    name: Verify head (image version and prow job)
+  verify-release:
+    name: Verify release
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.gen-version.outputs.VERSION }}
 
     steps:
       - name: Checkout code
@@ -19,23 +16,31 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Verify that the current branch has a name that starts with 'release-'
+      - name: Generate version number
+        id: gen-version
         run: |
-          CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
-          if [[ "$CURRENT_BRANCH" == release-* ]]; then
-            echo "Branch name starts with 'release-'."
-          else
-            echo "Branch name does not start with 'release-'."
-            exit 1
-          fi
+          # get script
+          GET_VERSION=$(mktemp /tmp/get-version-from-branch.XXXXX)
+          curl -L https://raw.githubusercontent.com/kyma-project/eventing-tools/main/hack/scripts/get-version-from-branch.sh -o "${GET_VERSION}"
+          chmod +x "${GET_VERSION}"
+          # get version via script
+          VERSION=$("${GET_VERSION}")
+          # push version to output environment file
+          echo "VERSION=${VERSION}" >> $GITHUB_OUTPUT
 
       - name: Check image Tag
-        run: ./scripts/check_tag_info.sh ${{ github.event.inputs.name }}
+        env:
+          VERSION: ${{ steps.gen-version.outputs.VERSION }}
+        run: ./scripts/check_sec-scanners-config.sh $VERSION
 
   create-draft:
     name: Create draft release
     needs: verify-head-status
     runs-on: ubuntu-latest
+    env:
+      VERSION: ${{ needs.verify-release.outputs.VERSION }}
+    outputs:
+      release_id: ${{ steps.create-draft.outputs.release_id }}
 
     steps:
       - name: Checkout code
@@ -46,36 +51,33 @@ jobs:
       - name: Create changelog
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: ./scripts/create_changelog.sh ${{ github.event.inputs.name }}
+        run: ./scripts/create_changelog.sh $VERSION
 
       - name: Create draft release
         id: create-draft
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          RELEASE_ID=$(./scripts/create_draft_release.sh ${{ github.event.inputs.name }})
+          RELEASE_ID=$(./scripts/create_draft_release.sh $VERSION
           echo "release_id=$RELEASE_ID" >> $GITHUB_OUTPUT
 
       - name: Create lightweight tag
         run: |
-          git tag ${{ github.event.inputs.name }}
-          git push origin ${{ github.event.inputs.name }}
+          git tag $VERSION
+          git push origin $VERSION
 
       - name: Verify job status
         run: ./scripts/verify-status.sh ${{ github.ref_name }} 600 10 30
 
       - name: Create and upload eventing-manager.yaml and eventing-default-cr.yaml
         env:
-          PULL_BASE_REF: ${{ github.event.inputs.name }}
+          PULL_BASE_REF: $VERSION
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          IMG: "europe-docker.pkg.dev/kyma-project/prod/eventing-manager:${{ github.event.inputs.name }}"
+          IMG: "europe-docker.pkg.dev/kyma-project/prod/eventing-manager:${VERSION}"
           MODULE_REGISTRY: "europe-docker.pkg.dev/kyma-project/prod/unsigned"
           KUSTOMIZE_VERSION: "v4.5.6"
         run: |
           ./scripts/render_and_upload_manifests.sh
-
-    outputs:
-      release_id: ${{ steps.create-draft.outputs.release_id }}
 
   publish-release:
     name: Publish release

--- a/scripts/check_sec-scanners-config.sh
+++ b/scripts/check_sec-scanners-config.sh
@@ -1,10 +1,12 @@
 #!/usr/bin/env bash
 
-##############################
-# Check tags in security-scan-config.yaml
-# Image Tag, rc-tag
-##############################
+# This script checks thate the RC-Tag and the eventing-manager image have the tag of the corresponding release.
 
+# Error handling:
+set -o nounset  # treat unset variables as an error and exit immediately.
+set -o errexit  # exit immediately when a command fails.
+set -E          # needs to be set if we want the ERR trap
+set -o pipefail # prevents errors in a pipeline from being masked
 
 # Get release version
 DESIRED_TAG="${1:-"main"}"
@@ -19,12 +21,12 @@ RC_TAG=$(cat sec-scanners-config.yaml | grep "${RC_TAG_TO_CHECK}" | cut -d : -f 
 
 # Check IMAGE_TAG and required image tag
 if [[ "$IMAGE_TAG" != "$DESIRED_TAG" ]] || [[ "$RC_TAG" != "$DESIRED_TAG" ]]; then
-  # ERROR: Tag issue
-  echo "Tags are not correct:
+	# ERROR: Tag issue
+	echo "Tags are not correct:
   - wanted: $DESIRED_TAG
   - security-scanner image tag: $IMAGE_TAG
   - rc-tag: $RC_TAG"
-  exit 1
+	exit 1
 fi
 
 # OK: Everything is fine


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

This PR cherry-picks the changes to the `Create workflow`, that will remove the manual input of a release version, to the branch `release-1.0`

For more details see the [original PR](https://github.com/kyma-project/eventing-manager/pull/396) to `main`.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
#360 
