### PR TITLE
Updated backend switching job to use API Rules instead of port-forward

### DIFF
--- a/.github/workflows/e2e-backend-switching-reuseable.yml
+++ b/.github/workflows/e2e-backend-switching-reuseable.yml
@@ -115,6 +115,16 @@ jobs:
 
       - name: Setup eventing tests
         run: |
+          # create API Rules for EPP and Sink.
+          export DOMAIN_TO_EXPOSE_WORKLOADS="$(kubectl get cm -n kube-system shoot-info -o=jsonpath='{.data.domain}')"
+          ./hack/e2e/scripts/expose_epp_and_sink.sh
+          # define URLs.
+          export SINK_PORT_FORWARDED_URL=https://sink-e2e-tests.${DOMAIN_TO_EXPOSE_WORKLOADS}
+          export PUBLISHER_URL=https://epp-e2e-tests.${DOMAIN_TO_EXPOSE_WORKLOADS}
+          # export ENVs to Github for all next steps.
+          echo "SINK_PORT_FORWARDED_URL=${SINK_PORT_FORWARDED_URL}" >> $GITHUB_ENV
+          echo "PUBLISHER_URL=${PUBLISHER_URL}" >> $GITHUB_ENV
+          # setup e2e tests.
           make e2e-eventing-setup
 
       - name: Test eventing with NATS
@@ -130,8 +140,6 @@ jobs:
         env:
           BACKEND_TYPE: "EventMesh"
         run: |
-          # wait for subscriptions to be ready.
-          make e2e-eventing-setup
           # run tests.
           make e2e-eventing
 
@@ -142,8 +150,6 @@ jobs:
 
       - name: Test eventing again with NATS
         run: |
-          # wait for subscriptions to be ready.
-          make e2e-eventing-setup
           # run tests.
           make e2e-eventing
 
@@ -170,6 +176,11 @@ jobs:
         if: failure()
         run: |
           kubectl get apigateways.operator.kyma-project.io -n kyma-system -o yaml
+
+      - name: Cleanup modules
+        if: ${{ always() }}
+        run: |
+          ./scripts/cleanup_modules.sh
 
       - name: Delete IAS application
         if: ${{ always() }}

--- a/hack/e2e/scripts/event_delivery_tests.sh
+++ b/hack/e2e/scripts/event_delivery_tests.sh
@@ -12,10 +12,19 @@ PID2=$!
 # This will kill all the port-forwarding. We need this to be in a function so we can even call it, if our tests fails
 # since `set -e` would stop the script in case of an failing test.
 function kill_port_forward() {
+  # save exit code of callee.
+  EXIT_CODE=$(echo $?)
+
+  # ignore if fails to kill port-forward ports,
+  set +o errexit  # continue when a command fails.
   echo "Killing the port-forwarding for port: 38081"
   kill ${PID1}
   echo "Killing the port-forwarding for port: 38071"
   kill ${PID2}
+  set -o errexit  # exit immediately when a command fails.
+
+  # exit with exit code of callee
+  exit ${EXIT_CODE}
 }
 # This kills the port-forwards even if the test fails.
 trap kill_port_forward ERR

--- a/hack/e2e/scripts/expose_epp_and_sink.sh
+++ b/hack/e2e/scripts/expose_epp_and_sink.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+
+# This script will create APIRules for publisher proxy and sink for e2e-tests.
+#
+# Usage: To run this script, set the following environment variables and run this script.
+# - API_RULE_GATEWAY (optional)
+# - DOMAIN_TO_EXPOSE_WORKLOADS (optional)
+
+# standard bash error handling
+set -o errexit  # exit immediately when a command fails.
+set -E          # needs to be set if we want the ERR trap
+set -o pipefail # prevents errors in a pipeline from being masked
+
+validate_and_default() {
+  # set default values
+  if [ -z "$API_RULE_GATEWAY" ]; then
+      export API_RULE_GATEWAY="kyma-gateway.kyma-system.svc.cluster.local"
+  fi
+
+  if [ -z "$DOMAIN_TO_EXPOSE_WORKLOADS" ]; then
+      export DOMAIN_TO_EXPOSE_WORKLOADS="$(kubectl get cm -n kube-system shoot-info -o=jsonpath='{.data.domain}')"
+  fi
+}
+
+create_api_rule_for_epp() {
+  cat <<EOF | kubectl apply -f -
+apiVersion: gateway.kyma-project.io/v1beta1
+kind: APIRule
+metadata:
+  name: epp-e2e-tests
+  namespace: default
+spec:
+  host: epp-e2e-tests.$DOMAIN_TO_EXPOSE_WORKLOADS
+  service:
+    name: eventing-publisher-proxy
+    namespace: kyma-system
+    port: 80
+  gateway: $API_RULE_GATEWAY
+  rules:
+    - path: /.*
+      methods: ["GET", "POST"]
+      accessStrategies:
+        - handler: allow
+          config: {}
+EOF
+}
+
+create_api_rule_for_sink() {
+  cat <<EOF | kubectl apply -f -
+apiVersion: gateway.kyma-project.io/v1beta1
+kind: APIRule
+metadata:
+  name: sink-e2e-tests
+  namespace: default
+spec:
+  host: sink-e2e-tests.$DOMAIN_TO_EXPOSE_WORKLOADS
+  service:
+    name: test-sink
+    namespace: eventing-tests
+    port: 80
+  gateway: $API_RULE_GATEWAY
+  rules:
+    - path: /.*
+      methods: ["GET", "POST"]
+      accessStrategies:
+        - handler: allow
+          config: {}
+EOF
+}
+
+wait_for_api_rules_readiness() {
+  echo "waiting for EPP APIRule to be ready..."
+  kubectl wait apirules.gateway.kyma-project.io -n default epp-e2e-tests --timeout=150s --for=jsonpath='{.status.APIRuleStatus.code}'=OK
+
+  echo "waiting for sink APIRule to be ready..."
+  kubectl wait apirules.gateway.kyma-project.io -n default sink-e2e-tests --timeout=150s --for=jsonpath='{.status.APIRuleStatus.code}'=OK
+}
+
+## Main logic
+
+validate_and_default
+
+create_api_rule_for_epp
+
+create_api_rule_for_sink
+
+wait_for_api_rules_readiness

--- a/scripts/cleanup_modules.sh
+++ b/scripts/cleanup_modules.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# This script will remove eventing related resources and all required modules.
+# Usage: No parameters are required to run this script.
+
+source "$(dirname "$0")/utils/log.sh"
+
+# standard bash error handling
+set -o nounset  # treat unset variables as an error and exit immediately.
+set -E          # needs to be set if we want the ERR trap
+set -o pipefail # prevents errors in a pipeline from being masked
+
+set +o errexit  # exit immediately when a command fails.
+
+log::banner "Deleting all Subscriptions"
+kubectl delete --timeout=120s --wait=false -A subscriptions --all
+
+log::banner "Deleting all API Rules"
+kubectl delete --timeout=120s --wait=false -A apirules.gateway.kyma-project.io --all
+
+log::banner "Uninstalling Eventing module"
+kubectl delete --timeout=120s --ignore-not-found -f https://github.com/kyma-project/eventing-manager/releases/latest/download/eventing_default_cr.yaml
+make undeploy
+
+log::banner "Uninstalling NATS module"
+kubectl delete --timeout=120s --ignore-not-found -f https://github.com/kyma-project/nats-manager/releases/latest/download/nats-default-cr.yaml
+kubectl delete --timeout=120s --wait=false --ignore-not-found -f https://github.com/kyma-project/nats-manager/releases/latest/download/nats-manager.yaml
+
+log::banner "Uninstalling API Gateway module"
+kubectl delete --timeout=120s --ignore-not-found -f https://github.com/kyma-project/api-gateway/releases/latest/download/apigateway-default-cr.yaml
+kubectl delete --timeout=120s --wait=false --ignore-not-found -f https://github.com/kyma-project/api-gateway/releases/latest/download/api-gateway-manager.yaml
+# Delete peer auth
+kubectl delete --timeout=120s --wait=false peerauthentication -n kyma-system ory-oathkeeper-maester-metrics
+
+log::banner "Uninstalling Istio module"
+kubectl delete --timeout=120s --ignore-not-found -f https://github.com/kyma-project/istio/releases/latest/download/istio-default-cr.yaml
+kubectl delete --timeout=120s --wait=false --ignore-not-found -f https://github.com/kyma-project/istio/releases/latest/download/istio-manager.yaml
+kubectl label namespace kyma-system istio-injection-
+
+exit 0


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Updated backend switching job to use API Rules instead of port-forward
- Added a step to cleanup cluster before deleting gardener cluster, otherwise the deletion stucks.
- Test run: [link](https://github.com/kyma-project/eventing-manager/actions/runs/7553998523/job/20566057872?pr=392)

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- https://github.com/kyma-project/eventing-manager/issues/131