### PR TITLE
Update eventing-publisher-proxy to image 1.0.1

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -87,7 +87,7 @@ spec:
           - name: PUBLISHER_LIMITS_MEMORY
             value: 128Mi
           - name: PUBLISHER_IMAGE
-            value: "europe-docker.pkg.dev/kyma-project/prod/event-publisher-proxy:v20231025-3f5d1600"
+            value: "europe-docker.pkg.dev/kyma-project/prod/eventing-publisher-proxy:1.0.1"
           - name: PUBLISHER_IMAGE_PULL_POLICY
             value: "IfNotPresent"
           - name: PUBLISHER_REPLICAS

--- a/sec-scanners-config.yaml
+++ b/sec-scanners-config.yaml
@@ -2,7 +2,7 @@ module-name: eventing
 rc-tag: 0.0.0
 protecode:
   - europe-docker.pkg.dev/kyma-project/prod/eventing-manager:v20231229-2f787759
-  - europe-docker.pkg.dev/kyma-project/prod/event-publisher-proxy:v20231025-3f5d1600
+  - europe-docker.pkg.dev/kyma-project/prod/eventing-publisher-proxy:1.0.1
   - europe-docker.pkg.dev/kyma-project/prod/eventing-webhook-certificates:1.7.0
 whitesource:
   language: golang-mod


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

With the new release of the [eventing-publisher-proxy:1.0.1](https://github.com/kyma-project/eventing-publisher-proxy/releases/tag/1.0.1) the image in the eventing-manager needs to be updated to this version.

Changes proposed in this pull request:

- Update EPP image to 1.0.1

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
[eventing-publisher-proxy/#45](https://github.com/kyma-project/eventing-publisher-proxy/issues/45)