### PR TITLE
Add missing steps

### DIFF
--- a/docs/user/tutorials/evnt-02-subs-with-multiple-filters.md
+++ b/docs/user/tutorials/evnt-02-subs-with-multiple-filters.md
@@ -137,7 +137,29 @@ curl -v -X POST \
 
 ## Verify the Event Delivery
 
-To verify that the events were properly delivered, check the logs of the Function (see [Verify the event delivery](https://kyma-project.io/#/02-get-started/04-trigger-workload-with-event?id=verify-the-event-delivery)).
+To verify that the event was properly delivered, check the logs of the Function:
+
+<!-- tabs:start -->
+
+#### **Kyma Dashboard**
+
+1. In Kyma Dashboard, return to the view of your `lastorder` Function.
+2. In the **Code** view, find the **Replicas of the Function** section.
+3. Click the name of your replica.
+4. Locate the **Containers** section and click on **View Logs**.
+
+#### **kubectl**
+
+Run:
+
+```bash
+kubectl logs \
+  -n default \
+  -l serverless.kyma-project.io/function-name=lastorder,serverless.kyma-project.io/resource=deployment \
+  -c function
+```
+
+<!-- tabs:end -->
 
 You see the received event in the logs:
 

--- a/docs/user/tutorials/evnt-03-type-cleanup.md
+++ b/docs/user/tutorials/evnt-03-type-cleanup.md
@@ -157,7 +157,29 @@ curl -v -X POST \
 
 ## Verify the Event Delivery
 
-To verify that the event was properly delivered, check the logs of the Function (see [Verify the event delivery](https://kyma-project.io/#/02-get-started/04-trigger-workload-with-event?id=verify-the-event-delivery)).
+To verify that the event was properly delivered, check the logs of the Function:
+
+<!-- tabs:start -->
+
+#### **Kyma Dashboard**
+
+1. In Kyma Dashboard, return to the view of your `lastorder` Function.
+2. In the **Code** view, find the **Replicas of the Function** section.
+3. Click the name of your replica.
+4. Locate the **Containers** section and click on **View Logs**.
+
+#### **kubectl**
+
+Run:
+
+```bash
+kubectl logs \
+  -n default \
+  -l serverless.kyma-project.io/function-name=lastorder,serverless.kyma-project.io/resource=deployment \
+  -c function
+```
+
+<!-- tabs:end -->
 
 You see the received event in the logs:
 

--- a/docs/user/tutorials/evnt-04-change-max-in-flight-in-sub.md
+++ b/docs/user/tutorials/evnt-04-change-max-in-flight-in-sub.md
@@ -163,7 +163,29 @@ done
 
 ## Verify the Event Delivery
 
-To verify that the events ware properly delivered, check the logs of the Function (see [Verify the event delivery](https://kyma-project.io/#/02-get-started/04-trigger-workload-with-event?id=verify-the-event-delivery)).
+To verify that the event was properly delivered, check the logs of the Function:
+
+<!-- tabs:start -->
+
+#### **Kyma Dashboard**
+
+1. In Kyma Dashboard, return to the view of your `lastorder` Function.
+2. In the **Code** view, find the **Replicas of the Function** section.
+3. Click the name of your replica.
+4. Locate the **Containers** section and click on **View Logs**.
+
+#### **kubectl**
+
+Run:
+
+```bash
+kubectl logs \
+  -n default \
+  -l serverless.kyma-project.io/function-name=lastorder,serverless.kyma-project.io/resource=deployment \
+  -c function
+```
+
+<!-- tabs:end -->
 
 You will see the received events in the logs as:
 

--- a/docs/user/tutorials/evnt-05-send-legacy-events.md
+++ b/docs/user/tutorials/evnt-05-send-legacy-events.md
@@ -91,7 +91,29 @@ You created the `lastorder` Function, and subscribed to the `order.received.v1` 
 
 ## Publish Legacy Events Using Kyma Eventing
 
-To verify that the event was properly delivered, check the logs of the Function (see [Verify the event delivery](https://kyma-project.io/#/02-get-started/04-trigger-workload-with-event?id=verify-the-event-delivery)).
+To verify that the event was properly delivered, check the logs of the Function:
+
+<!-- tabs:start -->
+
+#### **Kyma Dashboard**
+
+1. In Kyma Dashboard, return to the view of your `lastorder` Function.
+2. In the **Code** view, find the **Replicas of the Function** section.
+3. Click the name of your replica.
+4. Locate the **Containers** section and click on **View Logs**.
+
+#### **kubectl**
+
+Run:
+
+```bash
+kubectl logs \
+  -n default \
+  -l serverless.kyma-project.io/function-name=lastorder,serverless.kyma-project.io/resource=deployment \
+  -c function
+```
+
+<!-- tabs:end -->
 
 You see the received event in the logs:
 


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Added missing steps for verifying the event delivery in all four tutorials. The link to the Get Started doesn't work as the document no longer exists. 

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
