### PR TITLE
Correct post-eventing-manager-build name

### DIFF
--- a/.github/workflows/push-e2e-upgrade-test.yaml
+++ b/.github/workflows/push-e2e-upgrade-test.yaml
@@ -28,6 +28,6 @@ jobs:
     with:
       pre-upgrade-image-tag: ${{ needs.get-latest-release.outputs.latest_release_tag }}
       post-upgrade-image-tag: main
-      build-job-name: push-eventing-manager-build
+      build-job-name: post-eventing-manager-build
       build-job-commit-sha: ${{ github.sha }}
     secrets: inherit


### PR DESCRIPTION
**Description**
Build job for main push was incorrectly specified. Correct it with post-eventing-manager-build.
**Related issue(s)**
Main merge build job was incorrect `push-eventing-manager-build`