### PR TITLE
Change Eventing CR status to WARN if cannot connect to NATS

### DIFF
--- a/internal/controller/operator/eventing/controller.go
+++ b/internal/controller/operator/eventing/controller.go
@@ -575,11 +575,11 @@ func (r *Reconciler) reconcileNATSBackend(ctx context.Context,
 	if connErr := r.connectToNATS(eventingCR); connErr != nil {
 		if errors.Is(connErr, natsconnectionerrors.ErrCannotConnect) {
 			return kctrl.Result{}, reconcile.TerminalError(
-				r.syncStatusWithNATSErr(ctx, eventingCR, connErr, log),
+				r.syncStatusWithNATSState(ctx, operatorv1alpha1.StateWarning, eventingCR, connErr, log),
 			)
 		}
 
-		return kctrl.Result{}, r.syncStatusWithNATSErr(ctx, eventingCR, connErr, log)
+		return kctrl.Result{}, r.syncStatusWithNATSState(ctx, operatorv1alpha1.StateWarning, eventingCR, connErr, log)
 	}
 
 	// set NATSAvailable condition to true and update status

--- a/internal/controller/operator/eventing/integrationtests/natsconnection/integration_test.go
+++ b/internal/controller/operator/eventing/integrationtests/natsconnection/integration_test.go
@@ -6,6 +6,7 @@ import (
 	natstestutils "github.com/kyma-project/nats-manager/testutils"
 	"github.com/onsi/gomega"
 	gomegatypes "github.com/onsi/gomega/types"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	kappsv1 "k8s.io/api/apps/v1"
@@ -22,6 +23,9 @@ import (
 // Test_NATSConnection tests the Eventing CR status when connecting to NATS.
 func Test_NATSConnection(t *testing.T) {
 	// given
+
+	ErrAny := errors.New("any")
+
 	testCases := []struct {
 		name                    string
 		givenNATSConnectionMock func() *natsconnectionmocks.Connection
@@ -45,7 +49,7 @@ func Test_NATSConnection(t *testing.T) {
 			),
 		},
 		{
-			name: "Eventing CR should be in warning state if not connected to NATS",
+			name: "Eventing CR should be in warning state if the connect behaviour returned a cannot connect error",
 			givenNATSConnectionMock: func() *natsconnectionmocks.Connection {
 				conn := &natsconnectionmocks.Connection{}
 				conn.On("Connect", mock.Anything, mock.Anything).Return(natsconnectionerrors.ErrCannotConnect)
@@ -58,6 +62,25 @@ func Test_NATSConnection(t *testing.T) {
 				matchers.HaveStatusWarning(),
 				matchers.HaveBackendNotAvailableConditionWith(
 					natsconnectionerrors.ErrCannotConnect.Error(),
+					operatorv1alpha1.ConditionReasonNATSNotAvailable,
+				),
+				matchers.HaveFinalizer(),
+			),
+		},
+		{
+			name: "Eventing CR should be in warning state if the connect behaviour returned any error",
+			givenNATSConnectionMock: func() *natsconnectionmocks.Connection {
+				conn := &natsconnectionmocks.Connection{}
+				conn.On("Connect", mock.Anything, mock.Anything).Return(ErrAny)
+				conn.On("IsConnected").Return(false)
+				conn.On("RegisterReconnectHandler", mock.Anything).Return()
+				conn.On("RegisterDisconnectErrHandler", mock.Anything).Return()
+				return conn
+			},
+			wantMatches: gomega.And(
+				matchers.HaveStatusWarning(),
+				matchers.HaveBackendNotAvailableConditionWith(
+					ErrAny.Error(),
 					operatorv1alpha1.ConditionReasonNATSNotAvailable,
 				),
 				matchers.HaveFinalizer(),

--- a/internal/controller/operator/eventing/integrationtests/natsconnection/integration_test.go
+++ b/internal/controller/operator/eventing/integrationtests/natsconnection/integration_test.go
@@ -37,8 +37,6 @@ func Test_NATSConnection(t *testing.T) {
 				conn := &natsconnectionmocks.Connection{}
 				conn.On("Connect", mock.Anything, mock.Anything).Return(nil)
 				conn.On("IsConnected").Return(true)
-				conn.On("RegisterReconnectHandler", mock.Anything).Return()
-				conn.On("RegisterDisconnectErrHandler", mock.Anything).Return()
 				return conn
 			},
 			wantMatches: gomega.And(
@@ -54,8 +52,6 @@ func Test_NATSConnection(t *testing.T) {
 				conn := &natsconnectionmocks.Connection{}
 				conn.On("Connect", mock.Anything, mock.Anything).Return(natsconnectionerrors.ErrCannotConnect)
 				conn.On("IsConnected").Return(false)
-				conn.On("RegisterReconnectHandler", mock.Anything).Return()
-				conn.On("RegisterDisconnectErrHandler", mock.Anything).Return()
 				return conn
 			},
 			wantMatches: gomega.And(
@@ -73,8 +69,6 @@ func Test_NATSConnection(t *testing.T) {
 				conn := &natsconnectionmocks.Connection{}
 				conn.On("Connect", mock.Anything, mock.Anything).Return(ErrAny)
 				conn.On("IsConnected").Return(false)
-				conn.On("RegisterReconnectHandler", mock.Anything).Return()
-				conn.On("RegisterDisconnectErrHandler", mock.Anything).Return()
 				return conn
 			},
 			wantMatches: gomega.And(

--- a/internal/controller/operator/eventing/integrationtests/natsconnection/integration_test.go
+++ b/internal/controller/operator/eventing/integrationtests/natsconnection/integration_test.go
@@ -45,7 +45,7 @@ func Test_NATSConnection(t *testing.T) {
 			),
 		},
 		{
-			name: "Eventing CR should be in error state if not connected to NATS",
+			name: "Eventing CR should be in warning state if not connected to NATS",
 			givenNATSConnectionMock: func() *natsconnectionmocks.Connection {
 				conn := &natsconnectionmocks.Connection{}
 				conn.On("Connect", mock.Anything, mock.Anything).Return(natsconnectionerrors.ErrCannotConnect)
@@ -55,7 +55,7 @@ func Test_NATSConnection(t *testing.T) {
 				return conn
 			},
 			wantMatches: gomega.And(
-				matchers.HaveStatusError(),
+				matchers.HaveStatusWarning(),
 				matchers.HaveBackendNotAvailableConditionWith(
 					natsconnectionerrors.ErrCannotConnect.Error(),
 					operatorv1alpha1.ConditionReasonNATSNotAvailable,

--- a/test/utils/integration/integration.go
+++ b/test/utils/integration/integration.go
@@ -199,8 +199,6 @@ func NewTestEnvironment(config TestEnvironmentConfig, connMock *natsconnectionmo
 		connMock.On("Connect", mock.Anything, mock.Anything).Return(nil)
 		connMock.On("IsConnected").Return(true)
 		connMock.On("Disconnect").Return()
-		connMock.On("RegisterReconnectHandler", mock.Anything).Return()
-		connMock.On("RegisterDisconnectErrHandler", mock.Anything).Return()
 	}
 
 	// create a new watcher


### PR DESCRIPTION
**Description**

Change Eventing CR status to WARN if cannot connect to NATS, because this is something the Eventing user can fix. As part of this PR, I removed unused function calls from the connection mock.

**Related issue(s)**

- https://github.com/kyma-project/eventing-manager/issues/267