### PR TITLE
Use checkout GH action branch setting

### DIFF
--- a/.github/workflows/e2e-upgrade-test-reusable.yaml
+++ b/.github/workflows/e2e-upgrade-test-reusable.yaml
@@ -19,9 +19,10 @@ on:
       build-job-name:
         type: string
         description: "The name of the build job to wait for"
-      build-job-commit-sha:
+      commit-sha:
         type: string
-        description: "The commit sha"
+        description: "The commit sha of the new version"
+        required: true
 
 # PR:      main -> PR
 # main: release -> main
@@ -77,7 +78,7 @@ jobs:
         uses: kyma-project/wait-for-commit-status-action@2b3ffe09af8b6f40e1213d5fb7f91a7bd41ffb20
         with:
           context: ${{ inputs.build-job-name }}
-          commit_ref: "${{ inputs.build-job-commit-sha }}" # Note: 'github.event.pull_request.head.sha' is not same as 'github.sha' on pull requests.
+          commit_ref: "${{ inputs.commit-sha }}"
           timeout: 600000 # 10 minutes in milliseconds
           # The check interval is kept long otherwise it will exhaust the GitHub rate limit (More info: https://docs.github.com/en/rest/overview/resources-in-the-rest-api?apiVersion=2022-11-28#rate-limiting)
           check_interval: 60000 # 1 minute in milliseconds
@@ -88,6 +89,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.commit-sha }}
 
       - name: Install Eventing manager after upgrade  
         run: |

--- a/.github/workflows/e2e-upgrade-test-reusable.yaml
+++ b/.github/workflows/e2e-upgrade-test-reusable.yaml
@@ -8,20 +8,23 @@ env:
 on:
   workflow_call:
     inputs:
-      # image tag before upgrade
       pre-upgrade-image-tag:
         required: true
         type: string
-      # image tag after upgrade
+        description: "The image tag of the Eventing Manager before the upgrade"
       post-upgrade-image-tag:
         required: true
         type: string
-      # job name of the prow build job
+        description: "The image tag of the Eventing Manager after the upgrade"
       build-job-name:
         type: string
-      # commit sha of the PR or main branch commit
+        description: "The name of the build job to wait for"
       build-job-commit-sha:
         type: string
+        description: "The commit sha"
+
+# PR:      main -> PR
+# main: release -> main
 
 jobs:
   e2e-upgrade: # This job tests the upgrade of Eventing module from the latest image of the main branch to the current commit.
@@ -31,8 +34,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Pre-upgrade checkout
-        run: git checkout -b ${{ inputs.pre-upgrade-image-tag }}
+        with:
+          ref: ${{ inputs.pre-upgrade-image-tag }}
 
       - name: Install k3d tools
         run: make -C hack/ci/ install-k3d-tools
@@ -85,8 +88,6 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Post-upgrade checkout
-        run: git checkout -b ${{ inputs.post-upgrade-image-tag }}
 
       - name: Install Eventing manager after upgrade  
         run: |

--- a/.github/workflows/pull-e2e-upgrade-test.yaml
+++ b/.github/workflows/pull-e2e-upgrade-test.yaml
@@ -15,5 +15,5 @@ jobs:
       pre-upgrade-image-tag: main
       post-upgrade-image-tag: PR-${{ github.event.number }}
       build-job-name: pull-eventing-manager-build
-      build-job-commit-sha: ${{ github.event.pull_request.head.sha }}
+      commit-sha: ${{ github.event.pull_request.head.sha }}
     secrets: inherit

--- a/.github/workflows/push-e2e-upgrade-test.yaml
+++ b/.github/workflows/push-e2e-upgrade-test.yaml
@@ -29,5 +29,5 @@ jobs:
       pre-upgrade-image-tag: ${{ needs.get-latest-release.outputs.latest_release_tag }}
       post-upgrade-image-tag: main
       build-job-name: post-eventing-manager-build
-      build-job-commit-sha: ${{ github.sha }}
+      commit-sha: ${{ github.sha }}
     secrets: inherit


### PR DESCRIPTION
**Description**
Use checkout GH action branch setting
  * Set branch with checkout GH action
  * Don't set branch for post upgrade checkout
  * Use commit sha to checkout latest new version


**Related issue(s)**
post upgrade job failed