### PR TITLE
feat: malformatted EventMesh Secret causes warning state instead of Error state

### DIFF
--- a/internal/controller/operator/eventing/controller.go
+++ b/internal/controller/operator/eventing/controller.go
@@ -669,6 +669,12 @@ func (r *Reconciler) reconcileEventMeshBackend(ctx context.Context, eventing *op
 	// Start the EventMesh subscription controller
 	err = r.reconcileEventMeshSubManager(ctx, eventing, eventMeshSecret)
 	if err != nil {
+		// In case the the error is caused by a malformatted secret, we want to set the status to warning,
+		// to indicate the requirement of user interaction.
+		if IsMalformattedSecretErr(err) {
+			return kctrl.Result{}, r.syncSubManagerStatusWithNATSState(ctx, operatorv1alpha1.StateWarning, eventing,
+				ErrEventMeshSecretMalformatted, log)
+		}
 		return kctrl.Result{}, r.syncStatusWithSubscriptionManagerErr(ctx, eventing, err, log)
 	}
 	eventing.Status.SetSubscriptionManagerReadyConditionToTrue()

--- a/internal/controller/operator/eventing/controller_test.go
+++ b/internal/controller/operator/eventing/controller_test.go
@@ -452,8 +452,8 @@ func Test_stopNatsCRWatch(t *testing.T) {
 			testEnv.Reconciler.stopNATSCRWatch(eventing)
 
 			// Check the results
-			require.Equal(t, nil, testcase.watchNatsWatcher)
-			require.False(t, testcase.natsCRWatchStarted)
+			require.Nil(t, tc.watchNatsWatcher)
+			require.False(t, tc.natsCRWatchStarted)
 		})
 	}
 }

--- a/internal/controller/operator/eventing/eventmesh.go
+++ b/internal/controller/operator/eventing/eventmesh.go
@@ -343,21 +343,21 @@ func getSecretForPublisher(eventMeshSecret *kcorev1.Secret) (*kcorev1.Secret, er
 		return nil, newMalformattedSecretErr(err.Error())
 	}
 
-	for _, m := range messages {
-		if m.Broker.BrokerType == "saprestmgw" {
-			if len(m.OA2.ClientID) == 0 {
+	for _, msg := range messages {
+		if msg.Broker.BrokerType == "saprestmgw" {
+			if len(msg.OA2.ClientID) == 0 {
 				return nil, newMalformattedSecretErr("client ID is missing")
 			}
-			if len(m.OA2.ClientSecret) == 0 {
+			if len(msg.OA2.ClientSecret) == 0 {
 				return nil, newMalformattedSecretErr("client secret is missing")
 			}
-			if len(m.OA2.TokenEndpoint) == 0 {
+			if len(msg.OA2.TokenEndpoint) == 0 {
 				return nil, newMalformattedSecretErr("tokenendpoint is missing")
 			}
-			if len(m.OA2.GrantType) == 0 {
+			if len(msg.OA2.GrantType) == 0 {
 				return nil, newMalformattedSecretErr("granttype is missing")
 			}
-			if len(m.URI) == 0 {
+			if len(msg.URI) == 0 {
 				return nil, newMalformattedSecretErr("publish URL is missing")
 			}
 

--- a/internal/controller/operator/eventing/eventmesh.go
+++ b/internal/controller/operator/eventing/eventmesh.go
@@ -327,15 +327,15 @@ func getSecretForPublisher(eventMeshSecret *kcorev1.Secret) (*kcorev1.Secret, er
 		label.KeyName: label.ValueEventingPublisherProxy,
 	}
 
-	if _, ok := eventMeshSecret.Data["messaging"]; !ok {
-		return nil, newMalformattedSecretErr(EMSecretMessagingMissing)
-	}
-	messagingBytes := eventMeshSecret.Data["messaging"]
-
 	if _, ok := eventMeshSecret.Data["namespace"]; !ok {
 		return nil, newMalformattedSecretErr(EMSecretNamespaceMissing)
 	}
 	namespaceBytes := eventMeshSecret.Data["namespace"]
+
+	if _, ok := eventMeshSecret.Data["messaging"]; !ok {
+		return nil, newMalformattedSecretErr(EMSecretMessagingMissing)
+	}
+	messagingBytes := eventMeshSecret.Data["messaging"]
 
 	var messages []Message
 	err := json.Unmarshal(messagingBytes, &messages)

--- a/internal/controller/operator/eventing/eventmesh.go
+++ b/internal/controller/operator/eventing/eventmesh.go
@@ -28,13 +28,17 @@ const (
 	secretKeyTokenURL     = "token_url"
 	secretKeyCertsURL     = "certs_url"
 
+	EMSecretMessagingMissing      = "messaging is missing from EM secret"
+	EMSecretNamespaceMissing      = "namespace is missing from EM secret"
 	EventMeshSecretMissingMessage = "The specified EventMesh secret is not found. Please provide an existing secret."
+	EventMeshSecretMalformatted   = "The EventMesh secret data is not formatted properly."
 )
 
 var (
-	ErrEMSecretMessagingMissing = errors.New("messaging is missing from EM secret")
-	ErrEMSecretNamespaceMissing = errors.New("namespace is missing from EM secret")
-	ErrEventMeshSecretMissing   = errors.New(EventMeshSecretMissingMessage)
+	ErrEMSecretMessagingMissing    = errors.New(EMSecretMessagingMissing)
+	ErrEMSecretNamespaceMissing    = errors.New(EMSecretNamespaceMissing)
+	ErrEventMeshSecretMissing      = errors.New(EventMeshSecretMissingMessage)
+	ErrEventMeshSecretMalformatted = errors.New(EventMeshSecretMalformatted)
 )
 
 type oauth2Credentials struct {
@@ -42,6 +46,15 @@ type oauth2Credentials struct {
 	clientSecret []byte
 	tokenURL     []byte
 	certsURL     []byte
+}
+
+func newMalformattedSecretErr(e string) error {
+	// The new error is handled as a string (%s), the malformation error is wrapped as an Err.
+	return fmt.Errorf("%s: %w", e, ErrEventMeshSecretMalformatted)
+}
+
+func IsMalformattedSecretErr(err error) bool {
+	return errors.Is(err, ErrEventMeshSecretMalformatted)
 }
 
 func (r *Reconciler) reconcileEventMeshSubManager(ctx context.Context, eventing *v1alpha1.Eventing, eventMeshSecret *kcorev1.Secret) error {
@@ -315,37 +328,37 @@ func getSecretForPublisher(eventMeshSecret *kcorev1.Secret) (*kcorev1.Secret, er
 	}
 
 	if _, ok := eventMeshSecret.Data["messaging"]; !ok {
-		return nil, ErrEMSecretMessagingMissing
+		return nil, newMalformattedSecretErr(EMSecretMessagingMissing)
 	}
 	messagingBytes := eventMeshSecret.Data["messaging"]
 
 	if _, ok := eventMeshSecret.Data["namespace"]; !ok {
-		return nil, ErrEMSecretNamespaceMissing
+		return nil, newMalformattedSecretErr(EMSecretNamespaceMissing)
 	}
 	namespaceBytes := eventMeshSecret.Data["namespace"]
 
 	var messages []Message
 	err := json.Unmarshal(messagingBytes, &messages)
 	if err != nil {
-		return nil, err
+		return nil, newMalformattedSecretErr(err.Error())
 	}
 
-	for _, msg := range messages {
-		if msg.Broker.BrokerType == "saprestmgw" {
-			if len(msg.OA2.ClientID) == 0 {
-				return nil, errors.New("client ID is missing")
+	for _, m := range messages {
+		if m.Broker.BrokerType == "saprestmgw" {
+			if len(m.OA2.ClientID) == 0 {
+				return nil, newMalformattedSecretErr("client ID is missing")
 			}
-			if len(msg.OA2.ClientSecret) == 0 {
-				return nil, errors.New("client secret is missing")
+			if len(m.OA2.ClientSecret) == 0 {
+				return nil, newMalformattedSecretErr("client secret is missing")
 			}
-			if len(msg.OA2.TokenEndpoint) == 0 {
-				return nil, errors.New("tokenendpoint is missing")
+			if len(m.OA2.TokenEndpoint) == 0 {
+				return nil, newMalformattedSecretErr("tokenendpoint is missing")
 			}
-			if len(msg.OA2.GrantType) == 0 {
-				return nil, errors.New("granttype is missing")
+			if len(m.OA2.GrantType) == 0 {
+				return nil, newMalformattedSecretErr("granttype is missing")
 			}
-			if len(msg.URI) == 0 {
-				return nil, errors.New("publish URL is missing")
+			if len(m.URI) == 0 {
+				return nil, newMalformattedSecretErr("publish URL is missing")
 			}
 
 			secret.StringData = getSecretStringData(msg.OA2.ClientID, msg.OA2.ClientSecret, msg.OA2.TokenEndpoint, msg.OA2.GrantType, msg.URI, string(namespaceBytes))

--- a/internal/controller/operator/eventing/eventmesh_test.go
+++ b/internal/controller/operator/eventing/eventmesh_test.go
@@ -1120,32 +1120,29 @@ func Test_syncOauth2ClientIDAndSecret(t *testing.T) {
 }
 
 // Test_IsMalfromattedSecret verifies that the function IsMalformattedSecretErr asses correctly
-// if a given error is a malformatted secret error.
+// if a given error is a malformatted secret error or not.
 func Test_IsMalfromattedSecret(t *testing.T) {
-	t.Parallel()
-
 	testCases := []struct {
 		name       string
 		givenErr   error
 		wantResult bool
 	}{
 		{
-			name:       "should return true when error is ErrMalformedSecret",
+			name:       "should return true when an error is an ErrMalformedSecret",
 			givenErr:   ErrEventMeshSecretMalformatted,
 			wantResult: true,
 		}, {
-			name:       "should return true when error is a wrapped ErrMalformedSecret",
+			name:       "should return true when an error is a wrapped ErrMalformedSecret",
 			givenErr:   newMalformattedSecretErr("this error will wrap ErrMalformedSecret"),
 			wantResult: true,
 		}, {
-			name:       "should return false when error is not ErrMalformedSecret",
+			name:       "should return false when an error is not an ErrMalformedSecret",
 			givenErr:   fmt.Errorf("this is not a malformed secret error"),
 			wantResult: false,
 		},
 	}
 
 	for _, tc := range testCases {
-		t.Parallel()
 		t.Run(tc.name, func(t *testing.T) {
 			// when
 			result := IsMalformattedSecretErr(tc.givenErr)

--- a/internal/controller/operator/eventing/eventmesh_test.go
+++ b/internal/controller/operator/eventing/eventmesh_test.go
@@ -703,6 +703,7 @@ func Test_GetSecretForPublisher(t *testing.T) {
 			if testcase.expectedError != nil {
 				require.Error(t, err)
 				require.ErrorIs(t, err, ErrEventMeshSecretMalformatted)
+				require.True(t, IsMalformattedSecretErr(err)) // This is redundant but checks the functionality of the IsMalformattedSecretErr function.
 				require.ErrorContains(t, err, tc.expectedError.Error())
 				return
 			}

--- a/internal/controller/operator/eventing/eventmesh_test.go
+++ b/internal/controller/operator/eventing/eventmesh_test.go
@@ -703,7 +703,6 @@ func Test_GetSecretForPublisher(t *testing.T) {
 			if testcase.expectedError != nil {
 				require.Error(t, err)
 				require.ErrorIs(t, err, ErrEventMeshSecretMalformatted)
-				require.True(t, IsMalformattedSecretErr(err)) // This is redundant but checks the functionality of the IsMalformattedSecretErr function.
 				require.ErrorContains(t, err, tc.expectedError.Error())
 				return
 			}
@@ -1116,6 +1115,43 @@ func Test_syncOauth2ClientIDAndSecret(t *testing.T) {
 			require.Equal(t, testcase.givenSubManagerStarted, testEnv.Reconciler.isEventMeshSubManagerStarted)
 			require.Equal(t, testcase.shouldEventMeshSubManagerExist, testEnv.Reconciler.eventMeshSubManager != nil)
 			require.Equal(t, *testcase.wantCredentials, testEnv.Reconciler.oauth2credentials)
+		})
+	}
+}
+
+// Test_IsMalfromattedSecret verifies that the function IsMalformattedSecretErr asses correctly
+// if a given error is a malformatted secret error.
+func Test_IsMalfromattedSecret(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name       string
+		givenErr   error
+		wantResult bool
+	}{
+		{
+			name:       "should return true when error is ErrMalformedSecret",
+			givenErr:   ErrEventMeshSecretMalformatted,
+			wantResult: true,
+		}, {
+			name:       "should return true when error is a wrapped ErrMalformedSecret",
+			givenErr:   newMalformattedSecretErr("this error will wrap ErrMalformedSecret"),
+			wantResult: true,
+		}, {
+			name:       "should return false when error is not ErrMalformedSecret",
+			givenErr:   fmt.Errorf("this is not a malformed secret error"),
+			wantResult: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Parallel()
+		t.Run(tc.name, func(t *testing.T) {
+			// when
+			result := IsMalformattedSecretErr(tc.givenErr)
+
+			// then
+			require.Equal(t, tc.wantResult, result)
 		})
 	}
 }

--- a/internal/controller/operator/eventing/eventmesh_test.go
+++ b/internal/controller/operator/eventing/eventmesh_test.go
@@ -702,7 +702,8 @@ func Test_GetSecretForPublisher(t *testing.T) {
 			gotPublisherSecret, err := getSecretForPublisher(publisherSecret)
 			if testcase.expectedError != nil {
 				require.Error(t, err)
-				require.ErrorContains(t, err, testcase.expectedError.Error())
+				require.ErrorIs(t, err, ErrEventMeshSecretMalformatted)
+				require.ErrorContains(t, err, tc.expectedError.Error())
 				return
 			}
 			require.NoError(t, err)

--- a/internal/controller/operator/eventing/integrationtests/controller/integration_test.go
+++ b/internal/controller/operator/eventing/integrationtests/controller/integration_test.go
@@ -671,7 +671,7 @@ func Test_CreateEventingCR_EventMesh(t *testing.T) {
 
 			if !testcase.shouldEventMeshSecretNotFound {
 				// create EventMesh secret.
-				testEnvironment.EnsureEventMeshSecretCreated(t, testcase.givenEventing)
+				testEnvironment.EnsureDefaultEventMeshSecretCreated(t, tc.givenEventing)
 			}
 
 			originalKubeClient := testEnvironment.KubeClient
@@ -804,8 +804,8 @@ func Test_DeleteEventingCR(t *testing.T) {
 				testEnvironment.EnsureNATSResourceStateReady(t, nats)
 			} else {
 				// create eventing-webhook-auth secret.
-				testEnvironment.EnsureOAuthSecretCreated(t, testcase.givenEventing)
-				testEnvironment.EnsureEventMeshSecretCreated(t, testcase.givenEventing)
+				testEnvironment.EnsureOAuthSecretCreated(t, tc.givenEventing)
+				testEnvironment.EnsureDefaultEventMeshSecretCreated(t, tc.givenEventing)
 			}
 			testEnvironment.EnsureK8sResourceCreated(t, testcase.givenEventing)
 
@@ -936,7 +936,7 @@ func Test_WatcherNATSResource(t *testing.T) {
 				)
 				// create necessary EventMesh secrets
 				testEnvironment.EnsureOAuthSecretCreated(t, eventingResource)
-				testEnvironment.EnsureEventMeshSecretCreated(t, eventingResource)
+				testEnvironment.EnsureDefaultEventMeshSecretCreated(t, eventingResource)
 			} else {
 				eventingResource = utils.NewEventingCR(
 					utils.WithEventingCRNamespace(givenNamespace),

--- a/internal/controller/operator/eventing/integrationtests/controller/integration_test.go
+++ b/internal/controller/operator/eventing/integrationtests/controller/integration_test.go
@@ -2,6 +2,7 @@ package controller_test
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"os"
@@ -14,6 +15,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 	kappsv1 "k8s.io/api/apps/v1"
+	kcorev1 "k8s.io/api/core/v1"
 	kapiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	kmetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -577,6 +579,77 @@ func Test_WatcherEventingCRK8sObjects(t *testing.T) {
 	}
 }
 
+func Test_EventMesh_MalformattedSecret(t *testing.T) {
+
+	testCases := []struct {
+		name                    string
+		givenObjName            string
+		givenEventMeshNamespace string
+		givenMessages           []eventingcontroller.Message
+	}{
+		{
+			name:                    "should have ready state when EventMesh secret is malformatted",
+			givenObjName:            "something",
+			givenEventMeshNamespace: "event-mesh-namespace",
+			givenMessages: []eventingcontroller.Message{
+				{
+					Broker: eventingcontroller.Broker{
+						BrokerType: "broker-type",
+					},
+					OA2: eventingcontroller.OAuthCredentials{
+						ClientID:      "client-id",
+						ClientSecret:  "client-secret",
+						GrantType:     "grant-type",
+						TokenEndpoint: "token-endpoint",
+					},
+					URI: "uri",
+				}},
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			// given
+			eventingcontroller.IsDeploymentReady = func(deployment *kappsv1.Deployment) bool {
+				return true
+			}
+
+			// Create an unique namespace for this test run.
+			givenNamespace := fmt.Sprintf("namespace-%s", tc.givenObjName)
+			testEnvironment.EnsureNamespaceCreation(t, givenNamespace)
+
+			// Create an Eventing CR. We do not care about the details.
+			givenEveningCR := utils.NewEventingCR(
+				utils.WithEventMeshBackend(fmt.Sprintf("test-%s", tc.givenObjName)),
+				utils.WithEventingPublisherData(1, 1, "199m", "99Mi", "399m", "199Mi"),
+				utils.WithEventingEventTypePrefix("test-prefix"),
+			)
+
+			// Create a EventMesh Secret. This is the crucial part of the test.
+			// If the Secret is malformatted, the Eventing CR should have a warning state.
+			secretData, err := json.Marshal(tc.givenMessages)
+			if err != nil {
+				t.Fail()
+			}
+			secret := kcorev1.Secret{
+				ObjectMeta: kmetav1.ObjectMeta{
+					Name:      fmt.Sprintf("test-%s", tc.givenObjName),
+					Namespace: givenNamespace,
+				},
+				Data: map[string][]byte{
+					"namespace": []byte(tc.givenEventMeshNamespace),
+					"message":   secretData,
+				},
+			}
+			testEnvironment.EnsuretEventMeshSecretCreated(t, givenEveningCR, &secret)
+
+			// when
+
+		})
+	}
+}
+
 func Test_CreateEventingCR_EventMesh(t *testing.T) {
 	testCases := []struct {
 		name                          string
@@ -662,8 +735,7 @@ func Test_CreateEventingCR_EventMesh(t *testing.T) {
 			}
 
 			// create unique namespace for this test run.
-			givenNamespace := testcase.givenEventing.Namespace
-
+			givenNamespace := tc.givenEventing.Namespace
 			testEnvironment.EnsureNamespaceCreation(t, givenNamespace)
 
 			// create eventing-webhook-auth secret.

--- a/internal/controller/operator/eventing/integrationtests/controllerswitching/integration_test.go
+++ b/internal/controller/operator/eventing/integrationtests/controllerswitching/integration_test.go
@@ -166,10 +166,10 @@ func Test_Switching(t *testing.T) {
 			// create eventing-webhook-auth secret.
 			testEnvironment.EnsureOAuthSecretCreated(t, testcase.givenEventing)
 			// create EventMesh secret.
-			if testcase.givenEventing.Spec.Backend.Type == operatorv1alpha1.EventMeshBackendType {
-				testEnvironment.EnsureEventMeshSecretCreated(t, testcase.givenEventing)
-			} else if testcase.givenSwitchedEventing.Spec.Backend.Type == operatorv1alpha1.EventMeshBackendType {
-				testEnvironment.EnsureEventMeshSecretCreated(t, testcase.givenSwitchedEventing)
+			if tc.givenEventing.Spec.Backend.Type == operatorv1alpha1.EventMeshBackendType {
+				testEnvironment.EnsureDefaultEventMeshSecretCreated(t, tc.givenEventing)
+			} else if tc.givenSwitchedEventing.Spec.Backend.Type == operatorv1alpha1.EventMeshBackendType {
+				testEnvironment.EnsureDefaultEventMeshSecretCreated(t, tc.givenSwitchedEventing)
 			}
 
 			// create Eventing CR.

--- a/internal/controller/operator/eventing/integrationtests/without_apirule_crd/integration_test.go
+++ b/internal/controller/operator/eventing/integrationtests/without_apirule_crd/integration_test.go
@@ -91,7 +91,7 @@ func Test_EventMesh_APIRule_Dependency_Check(t *testing.T) {
 			testEnvironment.EnsureOAuthSecretCreated(t, testcase.givenEventing)
 
 			// create EventMesh secret.
-			testEnvironment.EnsureEventMeshSecretCreated(t, testcase.givenEventing)
+			testEnvironment.EnsureDefaultEventMeshSecretCreated(t, tc.givenEventing)
 
 			// when
 			// create Eventing CR.

--- a/test/utils/integration/integration.go
+++ b/test/utils/integration/integration.go
@@ -919,10 +919,10 @@ func (env TestEnvironment) EnsureDefaultEventMeshSecretCreated(t *testing.T, eve
 	t.Helper()
 	subarr := strings.Split(eventing.Spec.Backend.Config.EventMeshSecret, "/")
 	secret := testutils.NewEventMeshSecret(subarr[1], subarr[0])
-	env.EnsuretEventMeshSecretCreated(t, eventing, secret)
+	env.EnsureEventMeshSecretCreated(t, secret)
 }
 
-func (env TestEnvironment) EnsuretEventMeshSecretCreated(t *testing.T, eventing *v1alpha1.Eventing, secret *kcorev1.Secret) {
+func (env TestEnvironment) EnsureEventMeshSecretCreated(t *testing.T, secret *kcorev1.Secret) {
 	t.Helper()
 	env.EnsureK8sResourceCreated(t, secret)
 }

--- a/test/utils/integration/integration.go
+++ b/test/utils/integration/integration.go
@@ -915,10 +915,15 @@ func (env TestEnvironment) EnsureCABundleInjectedIntoWebhooks(t *testing.T) {
 	}, SmallTimeOut, SmallPollingInterval, "failed to ensure correctness of CABundle in Webhooks")
 }
 
-func (env TestEnvironment) EnsureEventMeshSecretCreated(t *testing.T, eventing *v1alpha1.Eventing) {
+func (env TestEnvironment) EnsureDefaultEventMeshSecretCreated(t *testing.T, eventing *v1alpha1.Eventing) {
 	t.Helper()
 	subarr := strings.Split(eventing.Spec.Backend.Config.EventMeshSecret, "/")
 	secret := testutils.NewEventMeshSecret(subarr[1], subarr[0])
+	env.EnsuretEventMeshSecretCreated(t, eventing, secret)
+}
+
+func (env TestEnvironment) EnsuretEventMeshSecretCreated(t *testing.T, eventing *v1alpha1.Eventing, secret *kcorev1.Secret) {
+	t.Helper()
 	env.EnsureK8sResourceCreated(t, secret)
 }
 

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -109,6 +109,8 @@ func NewAPIRuleCRD() *kapiextensionsv1.CustomResourceDefinition {
 	return result
 }
 
+// NewEventingCR creates a new Eventing CR with the given options.
+// If no options are provided, the default (e. g. random name and namespace) will be used.
 func NewEventingCR(opts ...EventingOption) *v1alpha1.Eventing {
 	name := fmt.Sprintf(NameFormat, GetRandString(randomNameLen))
 	namespace := fmt.Sprintf(NamespaceFormat, GetRandString(randomNameLen))
@@ -263,6 +265,17 @@ func NewDeployment(name, namespace string, annotations map[string]string) *kapps
 				},
 			},
 		},
+	}
+}
+
+func NewEventMeshSecretWithData(name, namespace string, data map[string][]byte) *kcorev1.Secret {
+	return &kcorev1.Secret{
+		ObjectMeta: kmetav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
+		Data: data,
+		Type: "Opaque",
 	}
 }
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- when the reconciler finds a EventMesh Secret that cannot be read due to missing fields or wrong formatting, it will return the warning state, not the error state, to indicate re requirement of user interactions.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
