### PR TITLE
fix: Malformatted EventMesh Secret causes warning status

### DIFF
--- a/.github/workflows/lint-go.yml
+++ b/.github/workflows/lint-go.yml
@@ -18,4 +18,4 @@ permissions:
 jobs:
   unit-test:
     name: "Run golangci-lint"
-    uses: kyma-project/eventing-tools/.github/workflows/lint-reusable.yml@main
+    uses: kyma-project/eventing-tools/.github/workflows/lint-go-reusable.yml@main

--- a/internal/controller/operator/eventing/controller.go
+++ b/internal/controller/operator/eventing/controller.go
@@ -669,6 +669,12 @@ func (r *Reconciler) reconcileEventMeshBackend(ctx context.Context, eventing *op
 	// Start the EventMesh subscription controller
 	err = r.reconcileEventMeshSubManager(ctx, eventing, eventMeshSecret)
 	if err != nil {
+		// In case the the error is caused by a malformatted secret, we want to set the status to warning,
+		// to indicate the requirement of user interaction.
+		if IsMalformattedSecretErr(err) {
+			return kctrl.Result{}, r.syncSubManagerStatusWithNATSState(ctx, operatorv1alpha1.StateWarning, eventing,
+				ErrEventMeshSecretMalformatted, log)
+		}
 		return kctrl.Result{}, r.syncStatusWithSubscriptionManagerErr(ctx, eventing, err, log)
 	}
 	eventing.Status.SetSubscriptionManagerReadyConditionToTrue()

--- a/internal/controller/operator/eventing/controller_test.go
+++ b/internal/controller/operator/eventing/controller_test.go
@@ -452,8 +452,8 @@ func Test_stopNatsCRWatch(t *testing.T) {
 			testEnv.Reconciler.stopNATSCRWatch(eventing)
 
 			// Check the results
-			require.Equal(t, nil, testcase.watchNatsWatcher)
-			require.False(t, testcase.natsCRWatchStarted)
+			require.Nil(t, tc.watchNatsWatcher)
+			require.False(t, tc.natsCRWatchStarted)
 		})
 	}
 }

--- a/internal/controller/operator/eventing/controller_test.go
+++ b/internal/controller/operator/eventing/controller_test.go
@@ -432,11 +432,10 @@ func Test_stopNatsCRWatch(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		testcase := tc
-		t.Run(testcase.name, func(t *testing.T) {
+		t.Run(tc.name, func(t *testing.T) {
 			// given
 			testEnv := NewMockedUnitTestEnvironment(t)
-			testEnv.Reconciler.natsCRWatchStarted = testcase.natsCRWatchStarted
+			testEnv.Reconciler.natsCRWatchStarted = tc.natsCRWatchStarted
 
 			// Create a fake Watcher
 			natsWatcher := new(watchermocks.Watcher)

--- a/internal/controller/operator/eventing/eventmesh.go
+++ b/internal/controller/operator/eventing/eventmesh.go
@@ -53,6 +53,7 @@ func newMalformattedSecretErr(e string) error {
 	return fmt.Errorf("%s: %w", e, ErrEventMeshSecretMalformatted)
 }
 
+// IsMalformattedSecretErr checks if the error is of type ErrEventMeshSecretMalformatted.
 func IsMalformattedSecretErr(err error) bool {
 	return errors.Is(err, ErrEventMeshSecretMalformatted)
 }

--- a/internal/controller/operator/eventing/eventmesh_test.go
+++ b/internal/controller/operator/eventing/eventmesh_test.go
@@ -695,19 +695,18 @@ func Test_GetSecretForPublisher(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		testcase := tc
-		t.Run(testcase.name, func(t *testing.T) {
-			publisherSecret := secretFor(testcase.messagingData, testcase.namespaceData)
+		t.Run(tc.name, func(t *testing.T) {
+			publisherSecret := secretFor(tc.messagingData, tc.namespaceData)
 
 			gotPublisherSecret, err := getSecretForPublisher(publisherSecret)
-			if testcase.expectedError != nil {
+			if tc.expectedError != nil {
 				require.Error(t, err)
 				require.ErrorIs(t, err, ErrEventMeshSecretMalformatted)
 				require.ErrorContains(t, err, tc.expectedError.Error())
 				return
 			}
 			require.NoError(t, err)
-			require.Equal(t, testcase.expectedSecret, gotPublisherSecret, "invalid publisher secret")
+			require.Equal(t, tc.expectedSecret, gotPublisherSecret, "invalid publisher secret")
 		})
 	}
 }

--- a/internal/controller/operator/eventing/eventmesh_test.go
+++ b/internal/controller/operator/eventing/eventmesh_test.go
@@ -1144,10 +1144,10 @@ func Test_IsMalfromattedSecret(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			// when
+			// When:
 			result := IsMalformattedSecretErr(tc.givenErr)
 
-			// then
+			// Then:
 			require.Equal(t, tc.wantResult, result)
 		})
 	}

--- a/internal/controller/operator/eventing/integrationtests/controller/integration_test.go
+++ b/internal/controller/operator/eventing/integrationtests/controller/integration_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"strings"
 	"testing"
 
 	natsv1alpha1 "github.com/kyma-project/nats-manager/api/v1alpha1"
@@ -14,6 +15,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 	kappsv1 "k8s.io/api/apps/v1"
+	kcorev1 "k8s.io/api/core/v1"
 	kapiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	kmetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -863,6 +865,128 @@ func Test_DeleteEventingCR(t *testing.T) {
 				testEnvironment.EnsureK8sClusterRoleBindingNotFound(t,
 					eventing.GetPublisherClusterRoleBindingName(*testcase.givenEventing), givenNamespace)
 			}
+		})
+	}
+}
+
+func Test_HandlingMalformedEventMeshSecret(t *testing.T) {
+	testcases := []struct {
+		name        string
+		givenData   map[string][]byte
+		wantMatcher gomegatypes.GomegaMatcher
+	}{
+		{
+			name: "EventingCR should have the `ready` status when EventMesh secret is valid",
+			givenData: map[string][]byte{
+				"management": []byte("foo"),
+				"messaging": []byte(`[
+				  {
+					"broker": {
+					  "type": "bar"
+					},
+					"oa2": {
+					  "clientid": "foo",
+					  "clientsecret": "foo",
+					  "granttype": "client_credentials",
+					  "tokenendpoint": "bar"
+					},
+					"protocol": [
+					  "amqp10ws"
+					],
+					"uri": "foo"
+				  },
+				  {
+					"broker": {
+					  "type": "foo"
+					},
+					"oa2": {
+					  "clientid": "bar",
+					  "clientsecret": "bar",
+					  "granttype": "client_credentials",
+					  "tokenendpoint": "foo"
+					},
+					"protocol": [
+					  "bar"
+					],
+					"uri": "bar"
+				  },
+				  {
+					"broker": {
+					  "type": "foo"
+					},
+					"oa2": {
+					  "clientid": "foo",
+					  "clientsecret": "bar",
+					  "granttype": "client_credentials",
+					  "tokenendpoint": "foo"
+					},
+					"protocol": [
+					  "httprest"
+					],
+					"uri": "bar"
+				  }
+				]`),
+				"namespace":         []byte("bar"),
+				"serviceinstanceid": []byte("foo"),
+				"xsappname":         []byte("bar"),
+			},
+			wantMatcher: gomega.And(
+				matchers.HaveStatusReady(),
+			),
+		},
+		{
+			name:      "EventingCR should be have the `warning` status when EventMesh secret data is empty",
+			givenData: map[string][]byte{},
+			wantMatcher: gomega.And(
+				matchers.HaveStatusWarning(),
+			),
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Given:
+			// We need to mock the deployment readiness check.
+			eventingcontroller.IsDeploymentReady = func(deployment *kappsv1.Deployment) bool {
+				return true
+			}
+
+			// Create an eventing CR with EventMesh backend.
+			givenEventingCR := utils.NewEventingCR(
+				utils.WithEventMeshBackend("test-secret-name2"),
+				utils.WithEventingPublisherData(2, 2, "199m", "99Mi", "399m", "199Mi"),
+				utils.WithEventingEventTypePrefix("test-prefix"),
+				utils.WithEventingDomain(utils.Domain),
+			)
+
+			// Create an unique Namespace for this test run.
+			givenNamespace := givenEventingCR.Namespace
+			testEnvironment.EnsureNamespaceCreation(t, givenNamespace)
+
+			// Create an eventing-webhook-auth Secret.
+			testEnvironment.EnsureOAuthSecretCreated(t, givenEventingCR)
+
+			// Create EventMesh secret. This is the crucial part of the test.
+			a := strings.Split(givenEventingCR.Spec.Backend.Config.EventMeshSecret, "/")
+			name, namespace := a[1], a[0]
+			secret := &kcorev1.Secret{
+				ObjectMeta: kmetav1.ObjectMeta{
+					Name:      name,
+					Namespace: namespace,
+				},
+				Data: tc.givenData,
+				Type: "Opaque",
+			}
+			testEnvironment.EnsureK8sResourceCreated(t, secret)
+
+			// When:
+			// Create the Eventing CR on the cluster.
+			testEnvironment.EnsureK8sResourceCreated(t, givenEventingCR)
+
+			// Then:
+			// Check if the EventingCR status has the expected status.
+			g := gomega.NewWithT(t)
+			testEnvironment.GetEventingAssert(g, givenEventingCR).Should(tc.wantMatcher)
 		})
 	}
 }

--- a/internal/controller/operator/eventing/integrationtests/controller/integration_test.go
+++ b/internal/controller/operator/eventing/integrationtests/controller/integration_test.go
@@ -999,6 +999,18 @@ func Test_HandlingMalformedEventMeshSecret(t *testing.T) {
 				matchers.HaveStatusWarning(),
 			),
 		},
+		{
+			name: "EventingCR should have the `warning` status when EventMesh secret data misses the `messaging` key",
+			givenData: map[string][]byte{
+				"management":        []byte("foo"),
+				"serviceinstanceid": []byte("foo"),
+				"xsappname":         []byte("bar"),
+				"namespace":         []byte("bar"),
+			},
+			wantMatcher: gomega.And(
+				matchers.HaveStatusWarning(),
+			),
+		},
 	}
 
 	for _, tc := range testcases {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- A malformatted EventMesh Secret no longer causes the error status but the warning status.
- Changes the linter to the common linter.

**Related issue(s)**
https://github.com/kyma-project/eventing-manager/issues/490