### PR TITLE
chore: added comments to explain that LastTransistionTime will not update

### DIFF
--- a/api/operator/v1alpha1/status.go
+++ b/api/operator/v1alpha1/status.go
@@ -19,6 +19,7 @@ func (es *EventingStatus) UpdateConditionBackendAvailable(status kmetav1.Conditi
 		Reason:             string(reason),
 		Message:            message,
 	}
+	// meta.SetStatusCondition will update LastTransitionTime only when `Status` is changed.
 	meta.SetStatusCondition(&es.Conditions, condition)
 }
 
@@ -32,6 +33,7 @@ func (es *EventingStatus) UpdateConditionPublisherProxyReady(status kmetav1.Cond
 		Reason:             string(reason),
 		Message:            message,
 	}
+	// LastTransitionTime will only be updated when `Status` is changed.
 	meta.SetStatusCondition(&es.Conditions, condition)
 }
 
@@ -45,6 +47,7 @@ func (es *EventingStatus) UpdateConditionWebhookReady(status kmetav1.ConditionSt
 		Reason:             string(reason),
 		Message:            message,
 	}
+	// meta.SetStatusCondition will update LastTransitionTime only when `Status` is changed.
 	meta.SetStatusCondition(&es.Conditions, condition)
 }
 
@@ -58,6 +61,7 @@ func (es *EventingStatus) UpdateConditionSubscriptionManagerReady(status kmetav1
 		Reason:             string(reason),
 		Message:            message,
 	}
+	// meta.SetStatusCondition will update LastTransitionTime only when `Status` is changed.
 	meta.SetStatusCondition(&es.Conditions, condition)
 }
 
@@ -71,6 +75,7 @@ func (es *EventingStatus) UpdateConditionDeletion(status kmetav1.ConditionStatus
 		Reason:             string(reason),
 		Message:            message,
 	}
+	// meta.SetStatusCondition will update LastTransitionTime only when `Status` is changed.
 	meta.SetStatusCondition(&es.Conditions, condition)
 }
 


### PR DESCRIPTION
…date

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- added comments to explain that LastTransistionTime will not update.
- As per the definition of [meta.SetStatusCondition](https://github.com/kubernetes/apimachinery/blob/d82afe1e363acae0e8c0953b1bc230d65fdb50e2/pkg/api/meta/conditions.go#L31), the LastTransitionTime will only be updated when `Status` is changed.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- https://github.com/kyma-project/eventing-manager/issues/542