### PR TITLE
fix: change NATS CR wait for Warning status

### DIFF
--- a/.github/workflows/e2e-backend-switching-reuseable.yml
+++ b/.github/workflows/e2e-backend-switching-reuseable.yml
@@ -111,7 +111,7 @@ jobs:
         run: |
           make -C hack/ci/ wait-istio-cr-ready
           make -C hack/ci/ wait-api-gateway-cr-ready
-          make -C hack/ci/ wait-nats-cr-ready
+          make -C hack/ci/ wait-nats-cr-warning
           make -C hack/ci/ wait-eventing-cr-ready-with-backend ACTIVE_BACKEND=NATS
 
       - name: Setup eventing tests

--- a/hack/ci/Makefile
+++ b/hack/ci/Makefile
@@ -51,6 +51,10 @@ apply-peerauthentication-crd:
 wait-nats-cr-ready:
 	kubectl wait nats.operator.kyma-project.io -n kyma-system eventing-nats --timeout=300s --for=jsonpath='{.status.state}'=Ready
 
+.PHONY: wait-nats-cr-warning
+wait-nats-cr-warning:
+	kubectl wait nats.operator.kyma-project.io -n kyma-system eventing-nats --timeout=300s --for=jsonpath='{.status.state}'=Warning
+
 .PHONY: wait-eventing-cr-ready
 wait-eventing-cr-ready:
 	kubectl wait eventing.operator.kyma-project.io -n kyma-system eventing --timeout=300s --for=jsonpath='{.status.state}'=Ready


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Change NATS CR wait for Warning status in backend-switching job, because in the latest version of nats-manager the CR will be in Warning state when the k8s is spread across less than 3 availability zones.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
