### PR TITLE
fix: link to default CR for NATS in docs

### DIFF
--- a/docs/user/02-configuration.md
+++ b/docs/user/02-configuration.md
@@ -38,7 +38,7 @@ Warnings indicate that user action is required, that is, the user must install t
 
 Use the following sample CRs as guidance. Each can be applied immediately when you [install](../contributor/installation.md) Eventing Manager.
 
-- [Default CR - NATS backend](https://github.com/kyma-project/eventing-manager/blob/main/config/samples/default.yaml)
+- [Default CR - NATS backend](https://github.com/kyma-project/eventing-manager/blob/main/config/samples/default_nats.yaml)
 - [Default CR - EventMesh backend](https://github.com/kyma-project/eventing-manager/blob/main/config/samples/default_eventmesh.yaml)
 
 ## Reference


### PR DESCRIPTION
Currently the link for the default CR which uses `NATS` backend is pointing to the one that has no backend. This PR fixes this.

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- fix link to the default cr for the NATS backend

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
