### PR TITLE
chore: bump EPP version to 1.1.1

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -87,7 +87,7 @@ spec:
           - name: PUBLISHER_LIMITS_MEMORY
             value: 128Mi
           - name: PUBLISHER_IMAGE
-            value: "europe-docker.pkg.dev/kyma-project/prod/eventing-publisher-proxy:1.1.0"
+            value: "europe-docker.pkg.dev/kyma-project/prod/eventing-publisher-proxy:1.1.1"
           - name: PUBLISHER_IMAGE_PULL_POLICY
             value: "IfNotPresent"
           - name: PUBLISHER_REPLICAS


### PR DESCRIPTION
**Description**

Cherry-pick the following commits from main to release a new EM version `1.2.2`:

- 8f948f0 (HEAD -> main, upstream/main) Bump EPP version to 1.1.1 (#657)
