### PR TITLE
K8s comp test.1.33

### DIFF
--- a/.github/workflows/k8s-compatibility-test.yml
+++ b/.github/workflows/k8s-compatibility-test.yml
@@ -168,7 +168,11 @@ jobs:
         if: failure()
         run: |
           kubectl get apigateways.operator.kyma-project.io -n kyma-system -o yaml
-
+           
+      - name: Sleep for 1 hour
+        if: ${{ always() }}
+        run: sleep 3600
+        
       - name: Cleanup modules
         if: ${{ always() }}
         run: |

--- a/.github/workflows/k8s-compatibility-test.yml
+++ b/.github/workflows/k8s-compatibility-test.yml
@@ -168,10 +168,6 @@ jobs:
         if: failure()
         run: |
           kubectl get apigateways.operator.kyma-project.io -n kyma-system -o yaml
-           
-      - name: Sleep for 1 hour
-        if: ${{ always() }}
-        run: sleep 3600
         
       - name: Cleanup modules
         if: ${{ always() }}

--- a/hack/ci/Makefile
+++ b/hack/ci/Makefile
@@ -34,7 +34,7 @@ install-istio-module:
 	kubectl label namespace kyma-system istio-injection=enabled --overwrite
 	kubectl apply -f https://github.com/kyma-project/istio/releases/latest/download/istio-manager.yaml
 	kubectl apply -f https://github.com/kyma-project/istio/releases/latest/download/istio-default-cr.yaml
-    kubectl wait --for=create MutatingWebhookConfiguration/istio-sidecar-injector
+	kubectl wait --for=create MutatingWebhookConfiguration/istio-sidecar-injector
 
 .PHONY: install-api-gateway-module
 install-api-gateway-module:

--- a/hack/ci/Makefile
+++ b/hack/ci/Makefile
@@ -34,7 +34,7 @@ install-istio-module:
 	kubectl label namespace kyma-system istio-injection=enabled --overwrite
 	kubectl apply -f https://github.com/kyma-project/istio/releases/latest/download/istio-manager.yaml
 	kubectl apply -f https://github.com/kyma-project/istio/releases/latest/download/istio-default-cr.yaml
-	kubectl wait --for=create MutatingWebhookConfiguration/istio-sidecar-injector
+	kubectl wait --for=create MutatingWebhookConfiguration/istio-sidecar-injector --timeout=600s
 
 .PHONY: install-api-gateway-module
 install-api-gateway-module:

--- a/hack/ci/Makefile
+++ b/hack/ci/Makefile
@@ -34,6 +34,7 @@ install-istio-module:
 	kubectl label namespace kyma-system istio-injection=enabled --overwrite
 	kubectl apply -f https://github.com/kyma-project/istio/releases/latest/download/istio-manager.yaml
 	kubectl apply -f https://github.com/kyma-project/istio/releases/latest/download/istio-default-cr.yaml
+    kubectl wait --for=create MutatingWebhookConfiguration/istio-sidecar-injector
 
 .PHONY: install-api-gateway-module
 install-api-gateway-module:


### PR DESCRIPTION

Changes proposed in this pull request:

- add wait for `MutatingWebhookConfiguration/istio-sidecar-injector` creation in `e2e` test setup flow to make sure Istio is able to inject side cars in all required workloads and prevent `connection reset by peer` caused by workloads that are by accident left out of mesh.
