### PR TITLE
chore: fix the label for AuthPolicy workload matcher

### DIFF
--- a/hack/e2e/scripts/expose_epp_and_sink.sh
+++ b/hack/e2e/scripts/expose_epp_and_sink.sh
@@ -76,7 +76,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: test-sink
+      name: test-sink
   action: ALLOW
   rules:
   - from:


### PR DESCRIPTION
Changes proposed in this pull request:

- fix the matcher label to allow internal trafic to test sink workload

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
